### PR TITLE
refactor: Update useQueryParams hook to accept optional streamUrl

### DIFF
--- a/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
+++ b/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
@@ -66,7 +66,7 @@ export const P2PVideoDemo = ({
     p2pUploaded: 0,
   });
 
-  const { queryParams, setURLQueryParams } = useQueryParams();
+  const { queryParams, setURLQueryParams } = useQueryParams(streamUrl);
 
   const trackers = useMemo(
     () => queryParams.trackers.split(","),
@@ -121,7 +121,7 @@ export const P2PVideoDemo = ({
 
     return PlayerComponent ? (
       <PlayerComponent
-        streamUrl={streamUrl ?? queryParams.streamUrl}
+        streamUrl={queryParams.streamUrl}
         announceTrackers={trackers}
         swarmId={queryParams.swarmId === "" ? undefined : queryParams.swarmId}
         onPeerConnect={onPeerConnect}


### PR DESCRIPTION
The useQueryParams hook in the P2PVideoDemo component has been updated to accept an optional streamUrl parameter. This allows for more flexibility in setting the initial stream URL when using the hook. The defaultParams object in the hook has also been modified to include the streamUrl parameter. This refactor improves the reusability and configurability of the useQueryParams hook.