### PR TITLE
Add missing data param in segment validator

### DIFF
--- a/packages/p2p-media-loader-core/src/p2p/peer.ts
+++ b/packages/p2p-media-loader-core/src/p2p/peer.ts
@@ -141,6 +141,7 @@ export class Peer {
         const { request, controls } = downloadingContext;
 
         const isWrongSegment =
+          !request.data ||
           downloadingContext.request.segment.externalId !== command.i ||
           downloadingContext.requestId !== command.r;
 
@@ -164,7 +165,7 @@ export class Peer {
           (await this.peerConfig.validateP2PSegment?.(
             request.segment.url,
             request.segment.byteRange,
-            request.data!
+            request.data
           )) ?? true;
 
         if (this.downloadingContext !== downloadingContext) return;

--- a/packages/p2p-media-loader-core/src/p2p/peer.ts
+++ b/packages/p2p-media-loader-core/src/p2p/peer.ts
@@ -164,6 +164,7 @@ export class Peer {
           (await this.peerConfig.validateP2PSegment?.(
             request.segment.url,
             request.segment.byteRange,
+            request.data!
           )) ?? true;
 
         if (this.downloadingContext !== downloadingContext) return;

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -155,7 +155,6 @@ export type CommonCoreConfig = {
  *  httpDownloadTimeWindow: 3000,
  *  p2pDownloadTimeWindow: 6000,
  *  swarmId: "custom swarm ID for video stream",
- *  cashedSegmentsCount: 1000,
  * }
  * ```
  *

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -380,6 +380,7 @@ export type StreamConfig = {
    * Optional function to validate a P2P segment before fully integrating it into the playback buffer.
    * @param url URL of the segment to validate.
    * @param byteRange Optional byte range of the segment.
+   * @param data: Downloaded segment data.
    * @returns A promise that resolves with a boolean indicating if the segment is valid.
    *
    * @default
@@ -387,7 +388,7 @@ export type StreamConfig = {
    * validateP2PSegment: undefined
    * ```
    */
-  validateP2PSegment?: (url: string, byteRange?: ByteRange) => Promise<boolean>;
+  validateP2PSegment?: (url: string, byteRange: ByteRange | undefined, data: ArrayBuffer) => Promise<boolean>;
 
   /**
    * Optional function to customize the setup of HTTP requests for segment downloads.


### PR DESCRIPTION
Also fixed a typo in the documentation

Added `data` as last param to not break the API, even if I think passing the `Segment` as first argument (as before) would better for future evolutions