### PR TITLE
fix: Publish config uses ES dist file

### DIFF
--- a/packages/p2p-media-loader-core/package.json
+++ b/packages/p2p-media-loader-core/package.json
@@ -35,8 +35,17 @@
   "exports": "./src/index.ts",
   "types": "./src/index.ts",
   "publishConfig": {
-    "exports": "./lib/index.js",
-    "types": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "default": "./dist/p2p-media-loader-core.es.js",
+        "types": "./lib/index.d.ts"
+      },
+      "./lib": {
+        "default": "./lib/index.js",
+        "types": "./lib/index.d.ts"
+      }
+    }
   },
   "sideEffects": false,
   "type": "module",

--- a/packages/p2p-media-loader-hlsjs/package.json
+++ b/packages/p2p-media-loader-hlsjs/package.json
@@ -33,8 +33,17 @@
   "exports": "./src/index.ts",
   "types": "./src/index.ts",
   "publishConfig": {
-    "exports": "./lib/index.js",
-    "types": "./lib/index.d.ts"
+    "types": "./lib/index.d.ts",
+    "exports": {
+      ".": {
+        "default": "./dist/p2p-media-loader-hlsjs.es.js",
+        "types": "./lib/index.d.ts"
+      },
+      "./lib": {
+        "default": "./lib/index.js",
+        "types": "./lib/index.d.ts"
+      }
+    }
   },
   "sideEffects": false,
   "type": "module",


### PR DESCRIPTION
Use ES dist file as default export so consumer don't have to rebuild all files

Especially useful for consumers to not polyfill node dependencies of bittorrent-tracker dependency