### PR TITLE
Fix request.data handling

### DIFF
--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -194,7 +194,7 @@ export class HybridLoader {
           break;
 
         case "succeed":
-          if (!request.data || !type) break;
+          if (!type) break;
           if (type === "http") {
             this.p2pLoaders.currentLoader.broadcastAnnouncement();
           }

--- a/packages/p2p-media-loader-core/src/p2p/peer.ts
+++ b/packages/p2p-media-loader-core/src/p2p/peer.ts
@@ -141,7 +141,6 @@ export class Peer {
         const { request, controls } = downloadingContext;
 
         const isWrongSegment =
-          !request.data ||
           downloadingContext.request.segment.externalId !== command.i ||
           downloadingContext.requestId !== command.r;
 
@@ -165,7 +164,7 @@ export class Peer {
           (await this.peerConfig.validateP2PSegment?.(
             request.segment.url,
             request.segment.byteRange,
-            request.data
+            request.data,
           )) ?? true;
 
         if (this.downloadingContext !== downloadingContext) return;

--- a/packages/p2p-media-loader-core/src/requests/request.ts
+++ b/packages/p2p-media-loader-core/src/requests/request.ts
@@ -100,6 +100,7 @@ export class Request {
     this._loadedBytes = 0;
     this.bytes = [];
     this._totalBytes = undefined;
+    this.finalData = undefined;
   }
 
   get status() {
@@ -123,8 +124,7 @@ export class Request {
     return this._totalBytes;
   }
 
-  get data(): ArrayBuffer | undefined {
-    if (this.status !== "succeed") return;
+  get data(): ArrayBuffer {
     if (!this.finalData) this.finalData = Utils.joinChunks(this.bytes);
     return this.finalData;
   }
@@ -284,12 +284,11 @@ export class Request {
 
     this.manageBandwidthCalculatorsState("stop");
     this.notReceivingBytesTimeout.clear();
-    this.finalData = Utils.joinChunks(this.bytes);
     this.setStatus("succeed");
     this._totalBytes = this._loadedBytes;
     this.onSegmentLoaded({
       segmentUrl: this.segment.url,
-      bytesLength: this.finalData.byteLength,
+      bytesLength: this.data.byteLength,
       downloadSource: this.currentAttempt.downloadSource,
       peerId:
         this.currentAttempt.downloadSource === "p2p"


### PR DESCRIPTION
`request.data` is always undefined here that causes peers' protocol failure:

```tsx
const isWrongSegment =
  !request.data ||
  downloadingContext.request.segment.externalId !== command.i ||
  downloadingContext.requestId !== command.r;
```