### PR TITLE
Fix: Abort previous engine request on new engine request creation

### DIFF
--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -132,6 +132,7 @@ export class HybridLoader {
         }
       }
 
+      this.engineRequest?.abort();
       this.engineRequest = engineRequest;
     } catch {
       engineRequest.reject();


### PR DESCRIPTION
The change is required for ExoPlayer integration, which is currently being developed. It doesn't change anything for Hls.js or Shaka integrations.