### PR TITLE
fix: stucked byte range requests

### DIFF
--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -155,7 +155,8 @@ export class HttpRequestExecutor {
             to !== undefined && from !== undefined ? to - from + 1 : undefined;
 
           if (
-            (totalBytes !== undefined && this.request.totalBytes !== totalBytes) ||
+            (responseExpectedBytesLength !== undefined &&
+              this.expectedBytesLength !== responseExpectedBytesLength) ||
             (from !== undefined && requestByteRange.start !== from) ||
             (to !== undefined &&
               requestByteRange.end !== undefined &&

--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -150,9 +150,13 @@ export class HttpRequestExecutor {
           ? parseContentRangeHeader(contentRangeHeader)
           : undefined;
         if (contentRange) {
-          const { from, to, total } = contentRange;
+          const { from, to } = contentRange;
+          const totalBytes = to !== undefined && from !== undefined
+            ? to - from + 1
+            : undefined
+
           if (
-            (total !== undefined && this.request.totalBytes !== total) ||
+            (totalBytes !== undefined && this.request.totalBytes !== totalBytes) ||
             (from !== undefined && requestByteRange.start !== from) ||
             (to !== undefined &&
               requestByteRange.end !== undefined &&

--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -151,9 +151,8 @@ export class HttpRequestExecutor {
           : undefined;
         if (contentRange) {
           const { from, to } = contentRange;
-          const totalBytes = to !== undefined && from !== undefined
-            ? to - from + 1
-            : undefined
+          const responseExpectedBytesLength =
+            to !== undefined && from !== undefined ? to - from + 1 : undefined;
 
           if (
             (totalBytes !== undefined && this.request.totalBytes !== totalBytes) ||


### PR DESCRIPTION
Due to an invalid check, the request throws even if it is valid.

`total` from `parseContentRangeHeader` is the total amount of bytes of the stream but `totalBytes` from `request` is the total amount of bytes of the request that we can infer from `to` and `from`