### PR TITLE
fix: disconnects with Aquatic tracker by associating peer ID with info hash

### DIFF
--- a/packages/p2p-media-loader-core/src/core.ts
+++ b/packages/p2p-media-loader-core/src/core.ts
@@ -27,6 +27,7 @@ import {
 } from "./utils/utils.js";
 import { TRACKER_CLIENT_VERSION_PREFIX } from "./utils/peer.js";
 import { SegmentStorage } from "./segment-storage/index.js";
+import { P2PTrackerClient } from "./p2p/tracker-client.js";
 
 /** Core class for managing media streams loading via P2P. */
 export class Core<TStream extends Stream = Stream> {
@@ -432,6 +433,7 @@ export class Core<TStream extends Stream = Stream> {
     this.segmentStorage = undefined;
     this.manifestResponseUrl = undefined;
     this.streamDetails = { isLive: false, activeLevelBitrate: 0 };
+    P2PTrackerClient.clearPeerIdCache();
   }
 
   private async initializeSegmentStorage() {

--- a/packages/p2p-media-loader-core/src/p2p/tracker-client.ts
+++ b/packages/p2p-media-loader-core/src/p2p/tracker-client.ts
@@ -37,6 +37,8 @@ function isSafariOrWkWebview() {
 }
 
 export class P2PTrackerClient {
+  private static readonly PEER_ID_BY_INFO_HASH = new Map<string, string>();
+
   private readonly streamShortId: string;
   private readonly client: TrackerClient;
   private readonly _peers = new Map<string, PeerItem>();
@@ -52,7 +54,11 @@ export class P2PTrackerClient {
     const streamHash = PeerUtil.getStreamHash(streamSwarmId);
     this.streamShortId = LoggerUtils.getStreamString(stream);
 
-    const peerId = PeerUtil.generatePeerId(config.trackerClientVersionPrefix);
+    let peerId = P2PTrackerClient.PEER_ID_BY_INFO_HASH.get(streamHash);
+    if (!peerId) {
+      peerId = PeerUtil.generatePeerId(config.trackerClientVersionPrefix);
+      P2PTrackerClient.PEER_ID_BY_INFO_HASH.set(streamHash, peerId);
+    }
 
     this.client = new TrackerClient({
       infoHash: utf8ToUintArray(streamHash),

--- a/packages/p2p-media-loader-core/src/p2p/tracker-client.ts
+++ b/packages/p2p-media-loader-core/src/p2p/tracker-client.ts
@@ -162,4 +162,8 @@ export class P2PTrackerClient {
     this.logger(`peer closed: ${peer.id}`);
     this._peers.delete(peer.id);
   };
+
+  static clearPeerIdCache() {
+    P2PTrackerClient.PEER_ID_BY_INFO_HASH.clear();
+  }
 }


### PR DESCRIPTION
Aquatic closes the WebSocket connection whenever the peer ID changes for the same info hash on a WebSocket connection. Associating the peer ID with the info hash resolves this issue.