### PR TITLE
feat: add validateHTTPSegment function

### DIFF
--- a/packages/p2p-media-loader-core/src/core.ts
+++ b/packages/p2p-media-loader-core/src/core.ts
@@ -65,6 +65,7 @@ export class Core<TStream extends Stream = Stream> {
       ],
     },
     validateP2PSegment: undefined,
+    validateHTTPSegment: undefined,
     httpRequestSetup: undefined,
     swarmId: undefined,
   };

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -409,6 +409,24 @@ export type StreamConfig = {
   ) => Promise<boolean>;
 
   /**
+   * Optional function to validate a HTTP segment before fully integrating it into the playback buffer.
+   * @param url URL of the segment to validate.
+   * @param byteRange Optional byte range of the segment.
+   * @param data Downloaded segment data.
+   * @returns A promise that resolves with a boolean indicating if the segment is valid.
+   *
+   * @default
+   * ```typescript
+   * validateHTTPSegment: undefined
+   * ```
+   */
+  validateHTTPSegment?: (
+    url: string,
+    byteRange: ByteRange | undefined,
+    data: ArrayBuffer,
+  ) => Promise<boolean>;
+
+  /**
    * Optional function to customize the setup of HTTP requests for segment downloads.
    * @param segmentUrl URL of the segment.
    * @param segmentByteRange The range of bytes requested for the segment.
@@ -631,7 +649,8 @@ export type RequestAbortErrorType = "abort" | "bytes-receiving-timeout";
 export type HttpRequestErrorType =
   | "http-error"
   | "http-bytes-mismatch"
-  | "http-unexpected-status-code";
+  | "http-unexpected-status-code"
+  | "http-segment-validation-failed";
 
 /** Defines the types of errors specific to peer-to-peer requests. */
 export type PeerRequestErrorType =


### PR DESCRIPTION
Can be useful when we don't control servers. Restore the behaviour implemented in p2p-media-loader < 1, that can be used in a "WebSeed" system.