### PR TITLE
chore: remove tracker.webtorrent.dev from defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This library makes it possible to build large-scale P2P mesh networks — often 
   - Video players: [Vidstack](https://www.vidstack.io/), [Clappr](http://clappr.io/), [MediaElement](https://www.mediaelementjs.com/), [Plyr](https://plyr.io/), [DPlayer](https://dplayer.diygod.dev/), [OpenPlayerJS](https://www.openplayerjs.com/), [PlayerJS](https://playerjs.com/) , and others that support Hls.js or Shaka video engines. These players can be integrated via custom integration with the library API.
 - Supports adaptive bitrate streaming of HLS and MPEG-DASH protocols
 - There is no need for server-side software for simple use cases. By default **P2P Media Loader** uses publicly available servers:
-  - WebTorrent trackers - [https://tracker.novage.com.ua/](https://tracker.novage.com.ua/), [https://tracker.webtorrent.dev/](https://tracker.webtorrent.dev/), [https://openwebtorrent.com/](https://openwebtorrent.com/)
+  - WebTorrent trackers - [https://tracker.novage.com.ua/](https://tracker.novage.com.ua/), [https://openwebtorrent.com/](https://openwebtorrent.com/)
   - STUN servers - [Public STUN server list](https://gist.github.com/mondain/b0ec1cf5f60ae726202e)
 
 ## Key Components of the P2P Network
@@ -85,7 +85,7 @@ All the components of the P2P network are free and open-source.
 There are many running public servers available on [Public STUN server list](https://gist.github.com/mondain/b0ec1cf5f60ae726202e).
 
 A compatible [**WebTorrent**](https://webtorrent.io/) tracker is required for WebRTC signaling and to create swarms of peers downloading the same media stream.
-A few running public trackers are available: [https://tracker.novage.com.ua/](https://tracker.novage.com.ua/), [https://tracker.webtorrent.dev/](https://tracker.webtorrent.dev/), [https://openwebtorrent.com/](https://openwebtorrent.com/).
+A few running public trackers are available: [https://tracker.novage.com.ua/](https://tracker.novage.com.ua/), [https://openwebtorrent.com/](https://openwebtorrent.com/).
 
 It is possible to run personal WebTorrent tracker using open-source implementations: [wt-tracker](https://github.com/Novage/wt-tracker), [Aquatic](https://github.com/greatest-ape/aquatic), [OpenWebtorrent Tracker](https://github.com/OpenWebTorrent/openwebtorrent-tracker), [bittorrent-tracker](https://github.com/webtorrent/bittorrent-tracker).
 

--- a/packages/p2p-media-loader-core/src/core.ts
+++ b/packages/p2p-media-loader-core/src/core.ts
@@ -55,7 +55,6 @@ export class Core<TStream extends Stream = Stream> {
     trackerClientVersionPrefix: TRACKER_CLIENT_VERSION_PREFIX,
     announceTrackers: [
       "wss://tracker.novage.com.ua",
-      "wss://tracker.webtorrent.dev",
       "wss://tracker.openwebtorrent.com",
     ],
     rtcConfig: {

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -342,7 +342,6 @@ export type StreamConfig = {
    * ```typescript
    * [
    *   "wss://tracker.novage.com.ua",
-   *   "wss://tracker.webtorrent.dev",
    *   "wss://tracker.openwebtorrent.com",
    * ]
    * ```


### PR DESCRIPTION
This PR removes tracker.webtorrent.dev from the default list of trackers and documentation since it is no longer available.