### PR TITLE
fix: improve P2P sharing by prioritizing P2P downloads

### DIFF
--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -310,6 +310,19 @@ export class HybridLoader {
         const isP2PLoadingRequest =
           request?.status === "loading" && request.downloadSource === "p2p";
 
+        const hasP2PFailedAttempt =
+          (request?.failedAttempts.p2pAttemptsCount ?? 0) > 0;
+
+        if (
+          !hasP2PFailedAttempt &&
+          this.p2pLoaders.currentLoader.isSegmentLoadedBySomeone(segment) &&
+          (isP2PLoadingRequest ||
+            this.requests.executingP2PCount < simultaneousP2PDownloads)
+        ) {
+          if (!isP2PLoadingRequest) this.loadThroughP2P(segment);
+          continue;
+        }
+
         if (this.requests.executingHttpCount < simultaneousHttpDownloads) {
           if (isP2PLoadingRequest) request.abortFromProcessQueue();
           this.loadThroughHttp(segment);

--- a/packages/p2p-media-loader-core/src/requests/request.ts
+++ b/packages/p2p-media-loader-core/src/requests/request.ts
@@ -373,6 +373,13 @@ class FailedRequestAttempts {
     );
   }
 
+  get p2pAttemptsCount() {
+    return this.attempts.reduce(
+      (sum, attempt) => (attempt.downloadSource === "p2p" ? sum + 1 : sum),
+      0,
+    );
+  }
+
   get lastAttempt(): Readonly<Required<RequestAttempt>> | undefined {
     return this.attempts[this.attempts.length - 1];
   }


### PR DESCRIPTION
This PR improves P2P sharing by actively prioritizing P2P downloads when a segment is known to be available from a peer. 

Specifically, it updates the `hybrid-loader.ts` logc to check if `isSegmentLoadedBySomeone` is true before defaulting to HTTP downloads. As long as there hasn't been a failed P2P attempt for the current request (`p2pAttemptsCount > 0`), the loader will now prefer initiating or continuing the P2P download. This ensures we maximize P2P network utilization instead of prematurely falling back to HTTP.