### PR TITLE
Optimize P2P connection slot usage during prefetching

### DIFF
--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -357,15 +357,6 @@ export class HybridLoader {
 
         if (this.requests.executingP2PCount < simultaneousP2PDownloads) {
           this.loadThroughP2P(segment);
-        } else if (
-          this.p2pLoaders.currentLoader.isSegmentLoadedBySomeone(segment)
-        ) {
-          if (
-            this.abortLastP2PLoadingInQueueAfterItem(queue, segment) &&
-            this.requests.executingP2PCount < simultaneousP2PDownloads
-          ) {
-            this.loadThroughP2P(segment);
-          }
         }
       }
     }


### PR DESCRIPTION
Removed the abort logic from prefetch branch.

Now, when a segment simply falls under isP2PDownloadable (prefetch), it will aggressively load via P2P only if there are open connection slots. If we are at the concurrency limit, it will just leave active, healthy downloads alone to maximize bandwidth and wait until they gracefully complete and free up the slots organically.

This should remove the artificial churn in connection slots and improve pure throughput during prefetching.