### PR TITLE
feat(core): delay initial HTTP fallback for first segments

### DIFF
--- a/packages/p2p-media-loader-core/src/core.ts
+++ b/packages/p2p-media-loader-core/src/core.ts
@@ -44,6 +44,7 @@ export class Core<TStream extends Stream = Stream> {
     simultaneousHttpDownloads: 2,
     simultaneousP2PDownloads: 3,
     highDemandTimeWindow: 15,
+    httpDownloadInitialTimeoutMs: 0,
     httpDownloadTimeWindow: 3000,
     p2pDownloadTimeWindow: 6000,
     webRtcMaxMessageSize: 64 * 1024 - 1,

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -414,6 +414,13 @@ export class HybridLoader {
   }
 
   private loadRandomThroughHttp() {
+    const { httpDownloadInitialTimeoutMs } = this.config;
+    const isInitialHttpWait =
+      httpDownloadInitialTimeoutMs > 0 &&
+      performance.now() - this.createdAt < httpDownloadInitialTimeoutMs;
+
+    if (isInitialHttpWait) return;
+
     const availableStorageCapacityPercent =
       this.getAvailableStorageCapacityPercent();
     if (availableStorageCapacityPercent <= 10) return;

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -279,12 +279,10 @@ export class HybridLoader {
       this.p2pLoaders.currentLoader.connectedPeerCount === 0;
 
     if (isInitialHttpWait) {
-      if (this.initialHttpDelayTimeoutId === undefined) {
-        this.initialHttpDelayTimeoutId = window.setTimeout(() => {
-          this.initialHttpDelayTimeoutId = undefined;
-          this.requestProcessQueueMicrotask();
-        }, httpDownloadInitialTimeoutMs - timeSinceStart);
-      }
+      this.initialHttpDelayTimeoutId ??= window.setTimeout(() => {
+        this.initialHttpDelayTimeoutId = undefined;
+        this.requestProcessQueueMicrotask();
+      }, httpDownloadInitialTimeoutMs - timeSinceStart);
     }
 
     if (

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -275,8 +275,7 @@ export class HybridLoader {
     const timeSinceStart = performance.now() - this.createdAt;
     const isInitialHttpWait =
       httpDownloadInitialTimeoutMs > 0 &&
-      timeSinceStart < httpDownloadInitialTimeoutMs &&
-      this.p2pLoaders.currentLoader.connectedPeerCount === 0;
+      timeSinceStart < httpDownloadInitialTimeoutMs;
 
     if (isInitialHttpWait) {
       this.initialHttpDelayTimeoutId ??= window.setTimeout(() => {

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -37,7 +37,9 @@ export class HybridLoader {
   private levelChangedTimestamp?: number;
   private lastQueueProcessingTimeStamp?: number;
   private randomHttpDownloadTimeout?: number;
+  private initialHttpDelayTimeoutId?: number;
   private isProcessQueueMicrotaskCreated = false;
+  private readonly createdAt = performance.now();
 
   constructor(
     private streamManifestUrl: string,
@@ -267,9 +269,26 @@ export class HybridLoader {
       simultaneousHttpDownloads,
       simultaneousP2PDownloads,
       httpErrorRetries,
+      httpDownloadInitialTimeoutMs,
     } = this.config;
 
+    const timeSinceStart = performance.now() - this.createdAt;
+    const isInitialHttpWait =
+      httpDownloadInitialTimeoutMs > 0 &&
+      timeSinceStart < httpDownloadInitialTimeoutMs &&
+      this.p2pLoaders.currentLoader.connectedPeerCount === 0;
+
+    if (isInitialHttpWait) {
+      if (this.initialHttpDelayTimeoutId === undefined) {
+        this.initialHttpDelayTimeoutId = window.setTimeout(() => {
+          this.initialHttpDelayTimeoutId = undefined;
+          this.requestProcessQueueMicrotask();
+        }, httpDownloadInitialTimeoutMs - timeSinceStart);
+      }
+    }
+
     if (
+      !isInitialHttpWait &&
       this.engineRequest?.shouldBeStartedImmediately &&
       this.engineRequest.status === "pending" &&
       this.requests.executingHttpCount < simultaneousHttpDownloads
@@ -323,13 +342,17 @@ export class HybridLoader {
           continue;
         }
 
-        if (this.requests.executingHttpCount < simultaneousHttpDownloads) {
+        if (
+          !isInitialHttpWait &&
+          this.requests.executingHttpCount < simultaneousHttpDownloads
+        ) {
           if (isP2PLoadingRequest) request.abortFromProcessQueue();
           this.loadThroughHttp(segment);
           continue;
         }
 
         if (
+          !isInitialHttpWait &&
           this.abortLastHttpLoadingInQueueAfterItem(queue, segment) &&
           this.requests.executingHttpCount < simultaneousHttpDownloads
         ) {
@@ -632,6 +655,7 @@ export class HybridLoader {
   destroy() {
     clearInterval(this.storageCleanUpIntervalId);
     clearTimeout(this.randomHttpDownloadTimeout);
+    clearTimeout(this.initialHttpDelayTimeoutId);
     this.storageCleanUpIntervalId = undefined;
     this.engineRequest?.abort();
     this.requests.destroy();

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -242,6 +242,8 @@ export type StreamConfig = {
   /**
    * Time in milliseconds to delay the HTTP fallback for the very first segments.
    * This gives the tracker time to discover peers when playback just started.
+   * A higher value gives a better chance to download the initial segments via P2P, thus improving the overall P2P ratio.
+   * However, setting this value too high can increase the playback startup time or even stall the download if peers are not immediately available.
    * If `0`, HTTP fallback happens immediately.
    *
    * @default

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -68,6 +68,7 @@ export type DefinedCoreConfig = CommonCoreConfig & {
 /** Represents a set of properties that can be dynamically modified at runtime. */
 export type DynamicStreamProperties =
   | "highDemandTimeWindow"
+  | "httpDownloadInitialTimeoutMs"
   | "httpDownloadTimeWindow"
   | "p2pDownloadTimeWindow"
   | "simultaneousHttpDownloads"
@@ -237,6 +238,18 @@ export type StreamConfig = {
    * ```
    */
   httpDownloadTimeWindow: number;
+
+  /**
+   * Time in milliseconds to delay the HTTP fallback for the very first segments.
+   * This gives the tracker time to discover peers when playback just started.
+   * If `0`, HTTP fallback happens immediately.
+   *
+   * @default
+   * ```typescript
+   * httpDownloadInitialTimeoutMs: 0
+   * ```
+   */
+  httpDownloadInitialTimeoutMs: number;
 
   /**
    * Defines the time window, in seconds, dedicated to pre-fetching media segments via Peer-to-Peer (P2P) downloads.

--- a/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
+++ b/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
@@ -128,7 +128,7 @@ export const P2PVideoDemo = ({
         coreOptions={{
           announceTrackers: trackers,
           swarmId: queryParams.swarmId === "" ? undefined : queryParams.swarmId,
-          httpDownloadInitialTimeoutMs: 10000,
+          httpDownloadInitialTimeoutMs: 5000,
         }}
         onPeerConnect={onPeerConnect}
         onPeerClose={onPeerClose}

--- a/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
+++ b/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
@@ -125,8 +125,11 @@ export const P2PVideoDemo = ({
     return PlayerComponent ? (
       <PlayerComponent
         streamUrl={queryParams.streamUrl}
-        announceTrackers={trackers}
-        swarmId={queryParams.swarmId === "" ? undefined : queryParams.swarmId}
+        coreOptions={{
+          announceTrackers: trackers,
+          swarmId: queryParams.swarmId === "" ? undefined : queryParams.swarmId,
+          httpDownloadInitialTimeoutMs: 5000
+        }}
         onPeerConnect={onPeerConnect}
         onPeerClose={onPeerClose}
         onChunkDownloaded={onChunkDownloaded}

--- a/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
+++ b/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
@@ -128,7 +128,7 @@ export const P2PVideoDemo = ({
         coreOptions={{
           announceTrackers: trackers,
           swarmId: queryParams.swarmId === "" ? undefined : queryParams.swarmId,
-          httpDownloadInitialTimeoutMs: 5000
+          httpDownloadInitialTimeoutMs: 10000,
         }}
         onPeerConnect={onPeerConnect}
         onPeerClose={onPeerClose}

--- a/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
+++ b/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
@@ -128,7 +128,7 @@ export const P2PVideoDemo = ({
         coreOptions={{
           announceTrackers: trackers,
           swarmId: queryParams.swarmId === "" ? undefined : queryParams.swarmId,
-          httpDownloadInitialTimeoutMs: 5000,
+          httpDownloadInitialTimeoutMs: 3000,
         }}
         onPeerConnect={onPeerConnect}
         onPeerClose={onPeerClose}

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/Hlsjs.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/Hlsjs.tsx
@@ -7,8 +7,7 @@ import Hls from "hls.js";
 
 export const HlsjsPlayer = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -23,10 +22,7 @@ export const HlsjsPlayer = ({
     const HlsWithP2P = HlsJsP2PEngine.injectMixin(Hls);
     const hls = new HlsWithP2P({
       p2p: {
-        core: {
-          announceTrackers,
-          swarmId,
-        },
+        core: coreOptions,
         onHlsJsCreated(hls) {
           subscribeToUiEvents({
             engine: hls.p2pEngine,
@@ -74,8 +70,7 @@ export const HlsjsPlayer = ({
     onChunkDownloaded,
     onChunkUploaded,
     streamUrl,
-    announceTrackers,
-    swarmId,
+    coreOptions,
   ]);
 
   return Hls.isSupported() ? (

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsClapprPlayer.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsClapprPlayer.tsx
@@ -13,8 +13,7 @@ const SCRIPTS = [
 
 export const HlsjsClapprPlayer = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -30,10 +29,7 @@ export const HlsjsClapprPlayer = ({
     }
 
     const engine = new HlsJsP2PEngine({
-      core: {
-        announceTrackers,
-        swarmId,
-      },
+      core: coreOptions,
     });
 
     subscribeToUiEvents({
@@ -71,13 +67,13 @@ export const HlsjsClapprPlayer = ({
     /* eslint-enable  */
   }, [
     areScriptsLoaded,
-    announceTrackers,
+    coreOptions,
     onChunkDownloaded,
     onChunkUploaded,
     onPeerConnect,
     onPeerClose,
     streamUrl,
-    swarmId,
+    
   ]);
 
   return Hls.isSupported() ? (

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsDPLayer.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsDPLayer.tsx
@@ -59,12 +59,11 @@ export const HlsjsDPlayer = ({
     };
   }, [
     streamUrl,
-    announceTrackers,
+    coreOptions,
     onPeerConnect,
     onPeerClose,
     onChunkDownloaded,
     onChunkUploaded,
-    
   ]);
 
   return Hls.isSupported() ? (

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsDPLayer.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsDPLayer.tsx
@@ -7,8 +7,7 @@ import Hls from "hls.js";
 
 export const HlsjsDPlayer = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -23,10 +22,7 @@ export const HlsjsDPlayer = ({
 
     const hls = new HlsWithP2P({
       p2p: {
-        core: {
-          announceTrackers,
-          swarmId,
-        },
+        core: coreOptions,
         onHlsJsCreated(hls) {
           subscribeToUiEvents({
             engine: hls.p2pEngine,
@@ -68,7 +64,7 @@ export const HlsjsDPlayer = ({
     onPeerClose,
     onChunkDownloaded,
     onChunkUploaded,
-    swarmId,
+    
   ]);
 
   return Hls.isSupported() ? (

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsMediaElement.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsMediaElement.tsx
@@ -8,8 +8,7 @@ import { PlayerProps } from "../../../types";
 
 export const HlsjsMediaElement = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -48,10 +47,7 @@ export const HlsjsMediaElement = ({
               onChunkUploaded,
             });
           },
-          core: {
-            announceTrackers,
-            swarmId,
-          },
+          core: coreOptions,
         },
       },
     });
@@ -66,13 +62,13 @@ export const HlsjsMediaElement = ({
     };
     /* eslint-enable  */
   }, [
-    announceTrackers,
+    coreOptions,
     onChunkDownloaded,
     onChunkUploaded,
     onPeerConnect,
     onPeerClose,
     streamUrl,
-    swarmId,
+    
   ]);
 
   return isHlsSupported ? (

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsOpenPlayer.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsOpenPlayer.tsx
@@ -8,8 +8,7 @@ import { createVideoElements, subscribeToUiEvents } from "../utils";
 
 export const HlsjsOpenPlayer = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -52,10 +51,7 @@ export const HlsjsOpenPlayer = ({
                 onChunkUploaded,
               });
             },
-            core: {
-              announceTrackers,
-              swarmId,
-            },
+            core: coreOptions,
           },
         },
         controls: {
@@ -93,13 +89,13 @@ export const HlsjsOpenPlayer = ({
 
     return () => cleanup();
   }, [
-    announceTrackers,
+    coreOptions,
     onChunkDownloaded,
     onChunkUploaded,
     onPeerConnect,
     onPeerClose,
     streamUrl,
-    swarmId,
+    
   ]);
 
   return Hls.isSupported() ? (

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsPlyr.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsPlyr.tsx
@@ -8,8 +8,7 @@ import { createVideoElements, subscribeToUiEvents } from "../utils";
 
 export const HlsjsPlyr = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -30,10 +29,7 @@ export const HlsjsPlyr = ({
 
     const hls = new HlsWithP2P({
       p2p: {
-        core: {
-          announceTrackers,
-          swarmId,
-        },
+        core: coreOptions,
         onHlsJsCreated(hls) {
           subscribeToUiEvents({
             engine: hls.p2pEngine,
@@ -78,13 +74,13 @@ export const HlsjsPlyr = ({
       hls.destroy();
     };
   }, [
-    announceTrackers,
+    coreOptions,
     onChunkDownloaded,
     onChunkUploaded,
     onPeerConnect,
     onPeerClose,
     streamUrl,
-    swarmId,
+    
   ]);
 
   return Hls.isSupported() ? (

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsVidstack.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsVidstack.tsx
@@ -18,8 +18,7 @@ import Hls from "hls.js";
 
 export const HlsjsVidstack = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -34,10 +33,7 @@ export const HlsjsVidstack = ({
 
         const config: HlsWithP2PConfig<typeof Hls> = {
           p2p: {
-            core: {
-              announceTrackers,
-              swarmId,
-            },
+            core: coreOptions,
             onHlsJsCreated: (hls) => {
               subscribeToUiEvents({
                 engine: hls.p2pEngine,
@@ -54,12 +50,12 @@ export const HlsjsVidstack = ({
       }
     },
     [
-      announceTrackers,
-      onChunkDownloaded,
+      coreOptions,
+    onChunkDownloaded,
       onChunkUploaded,
       onPeerConnect,
       onPeerClose,
-      swarmId,
+      
     ],
   );
 

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsVidstackIndexedDB.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsVidstackIndexedDB.tsx
@@ -20,7 +20,7 @@ import { IndexedDbStorage } from "../../../custom-segment-storage-example/indexe
 
 export const HlsjsVidstackIndexedDB = ({
   streamUrl,
-  announceTrackers,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -38,7 +38,7 @@ export const HlsjsVidstackIndexedDB = ({
         const config: HlsWithP2PConfig<typeof Hls> = {
           p2p: {
             core: {
-              announceTrackers,
+              ...coreOptions,
               customSegmentStorageFactory: storageFactory,
             },
             onHlsJsCreated: (hls) => {

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsVidstackIndexedDB.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsVidstackIndexedDB.tsx
@@ -57,8 +57,8 @@ export const HlsjsVidstackIndexedDB = ({
       }
     },
     [
-      announceTrackers,
-      onChunkDownloaded,
+      coreOptions,
+    onChunkDownloaded,
       onChunkUploaded,
       onPeerConnect,
       onPeerClose,

--- a/packages/p2p-media-loader-demo/src/components/players/shaka/Shaka.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/shaka/Shaka.tsx
@@ -7,8 +7,7 @@ import { createVideoElements, subscribeToUiEvents } from "../utils";
 
 export const Shaka = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -56,10 +55,7 @@ export const Shaka = ({
 
       const shakaP2PEngineInit = new ShakaP2PEngine(
         {
-          core: {
-            announceTrackers,
-            swarmId,
-          },
+          core: coreOptions,
         },
         shaka,
       );
@@ -101,13 +97,13 @@ export const Shaka = ({
 
     return cleanup;
   }, [
-    announceTrackers,
+    coreOptions,
     onChunkDownloaded,
     onChunkUploaded,
     onPeerConnect,
     onPeerClose,
     streamUrl,
-    swarmId,
+    
   ]);
 
   return shaka.Player.isBrowserSupported() ? (

--- a/packages/p2p-media-loader-demo/src/components/players/shaka/ShakaClappr.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/shaka/ShakaClappr.tsx
@@ -16,8 +16,7 @@ const SCRIPTS = [
 
 export const ShakaClappr = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -44,10 +43,7 @@ export const ShakaClappr = ({
     }
 
     const shakaP2PEngine = new ShakaP2PEngine({
-      core: {
-        announceTrackers,
-        swarmId,
-      },
+      core: coreOptions,
     });
 
     /* eslint-disable  */
@@ -82,13 +78,13 @@ export const ShakaClappr = ({
     };
     /* eslint-enable  */
   }, [
-    announceTrackers,
+    coreOptions,
     onChunkDownloaded,
     onChunkUploaded,
     onPeerConnect,
     onPeerClose,
     streamUrl,
-    swarmId,
+    
     areScriptsLoaded,
   ]);
 

--- a/packages/p2p-media-loader-demo/src/components/players/shaka/ShakaDPlayer.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/shaka/ShakaDPlayer.tsx
@@ -7,8 +7,7 @@ import { subscribeToUiEvents } from "../utils";
 
 export const ShakaDPlayer = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -26,10 +25,7 @@ export const ShakaDPlayer = ({
 
     const shakaP2PEngine = new ShakaP2PEngine(
       {
-        core: {
-          announceTrackers,
-          swarmId,
-        },
+        core: coreOptions,
       },
       shaka,
     );
@@ -66,13 +62,13 @@ export const ShakaDPlayer = ({
       player.destroy();
     };
   }, [
-    announceTrackers,
+    coreOptions,
     onChunkDownloaded,
     onChunkUploaded,
     onPeerConnect,
     onPeerClose,
     streamUrl,
-    swarmId,
+    
   ]);
 
   return shaka.Player.isBrowserSupported() ? (

--- a/packages/p2p-media-loader-demo/src/components/players/shaka/ShakaPlyr.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/shaka/ShakaPlyr.tsx
@@ -9,8 +9,7 @@ import { createVideoElements, subscribeToUiEvents } from "../utils";
 
 export const ShakaPlyr = ({
   streamUrl,
-  announceTrackers,
-  swarmId,
+  coreOptions,
   onPeerConnect,
   onPeerClose,
   onChunkDownloaded,
@@ -46,10 +45,7 @@ export const ShakaPlyr = ({
     const initPlayer = async () => {
       const shakaP2PEngineInit = new ShakaP2PEngine(
         {
-          core: {
-            announceTrackers,
-            swarmId,
-          },
+          core: coreOptions,
         },
         shaka,
       );
@@ -118,13 +114,13 @@ export const ShakaPlyr = ({
 
     return () => cleanup();
   }, [
-    announceTrackers,
+    coreOptions,
     onChunkDownloaded,
     onChunkUploaded,
     onPeerConnect,
     onPeerClose,
     streamUrl,
-    swarmId,
+    
   ]);
 
   return shaka.Player.isBrowserSupported() ? (

--- a/packages/p2p-media-loader-demo/src/types.ts
+++ b/packages/p2p-media-loader-demo/src/types.ts
@@ -21,8 +21,11 @@ export type PlayerName = (typeof PLAYERS)[PlayerKey];
 
 export type PlayerProps = {
   streamUrl: string;
-  announceTrackers: string[];
-  swarmId?: string;
+  coreOptions: {
+    announceTrackers: string[];
+    swarmId?: string;
+    httpDownloadInitialTimeoutMs?: number;
+  };
 } & Partial<
   Pick<
     CoreEventMap,
@@ -32,5 +35,5 @@ export type PlayerProps = {
 
 export type PlayerEvents = Omit<
   PlayerProps,
-  "streamUrl" | "announceTrackers" | "swarmId"
+  "streamUrl" | "coreOptions"
 >;


### PR DESCRIPTION
## Description
Introduce a configurable `httpDownloadInitialTimeoutMs` parameter that delays falling back to HTTP for the very first segments in the hybrid loader. This delay provides the P2P tracker (and WebRTC dialing) enough time to connect. If a connection is established inside that time window, segments will be loaded via P2P.

## Changes Included
- Add `httpDownloadInitialTimeoutMs` configurable in `StreamConfig`. Defaults to `0`.
- `hybrid-loader.ts` delays HTTP queue processing until the timeout triggers.
- Implemented state tracking to clear delays safely on stream termination.