### PR TITLE
refactor(core): simplify and improve hybrid loader queue processing

### DIFF
--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -299,7 +299,7 @@ export class HybridLoader {
 
       if (shouldStartLoadImmediatelyEngineRequest) {
         // Don't abort requests when processing engine request
-        // to avoid race condion with aborts in the requests queue
+        // to avoid race condition with aborts in the requests queue
 
         const canLoadThrougHttp =
           !isInitialHttpWait &&

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -327,7 +327,7 @@ export class HybridLoader {
       if (request?.status === "succeed") continue;
 
       if (statuses.isHighDemand) {
-        const canLoadThrougHttp =
+        const canLoadThroughHttp =
           !isInitialHttpWait &&
           (request?.failedAttempts.httpAttemptsCount ?? 0) < httpErrorRetries;
 
@@ -335,7 +335,7 @@ export class HybridLoader {
           // High-demand request is loading
 
           const shouldSwitchFromP2PToHttp =
-            canLoadThrougHttp &&
+            canLoadThroughHttp &&
             request.downloadSource === "p2p" &&
             (this.requests.executingHttpCount < simultaneousHttpDownloads ||
               this.abortLastHttpLoadingInQueueAfterItem(queue, segment));
@@ -351,7 +351,7 @@ export class HybridLoader {
         // High-demand request is not loading
 
         const shouldLoadThroughHttp =
-          canLoadThrougHttp &&
+          canLoadThroughHttp &&
           (this.requests.executingHttpCount < simultaneousHttpDownloads ||
             this.abortLastHttpLoadingInQueueAfterItem(queue, segment));
 

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -284,22 +284,39 @@ export class HybridLoader {
       }, httpDownloadInitialTimeoutMs - timeSinceStart);
     }
 
-    if (
-      !isInitialHttpWait &&
-      this.engineRequest?.shouldBeStartedImmediately &&
-      this.engineRequest.status === "pending" &&
-      this.requests.executingHttpCount < simultaneousHttpDownloads
-    ) {
-      const { segment } = this.engineRequest;
+    const { engineRequest } = this;
+    if (engineRequest) {
+      const { segment } = engineRequest;
       const request = this.requests.get(segment);
-      if (
-        !request ||
-        request.status === "not-started" ||
-        (request.status === "failed" &&
-          request.failedAttempts.httpAttemptsCount <
-            this.config.httpErrorRetries)
-      ) {
-        this.loadThroughHttp(segment);
+
+      const shouldStartLoadImmediatelyEngineRequest =
+        engineRequest.shouldBeStartedImmediately &&
+        engineRequest.status === "pending" &&
+        (!request ||
+          request.status === "not-started" ||
+          request.status === "failed" ||
+          request.status === "aborted");
+
+      if (shouldStartLoadImmediatelyEngineRequest) {
+        // Don't abort requests when processing engine request
+        // to avoid race condion with aborts in the requests queue
+
+        const canLoadThrougHttp =
+          !isInitialHttpWait &&
+          (request?.failedAttempts.httpAttemptsCount ?? 0) < httpErrorRetries &&
+          this.requests.executingHttpCount < simultaneousHttpDownloads;
+
+        if (canLoadThrougHttp) {
+          this.loadThroughHttp(segment);
+        } else {
+          const canLoadThrougP2P =
+            this.p2pLoaders.currentLoader.isSegmentLoadedBySomeone(segment) &&
+            this.requests.executingP2PCount < simultaneousP2PDownloads;
+
+          if (canLoadThrougP2P) {
+            this.loadThroughP2P(segment);
+          }
+        }
       }
     }
 
@@ -307,85 +324,59 @@ export class HybridLoader {
       const { statuses, segment } = item;
       const request = this.requests.get(segment);
 
+      if (request?.status === "succeed") continue;
+
       if (statuses.isHighDemand) {
-        if (
-          request?.downloadSource === "http" &&
-          request.status === "loading"
-        ) {
-          continue;
-        }
-
-        if (
-          request?.downloadSource === "http" &&
-          request.status === "failed" &&
-          request.failedAttempts.httpAttemptsCount >= httpErrorRetries
-        ) {
-          continue;
-        }
-
-        const isP2PLoadingRequest =
-          request?.status === "loading" && request.downloadSource === "p2p";
-
-        const hasP2PFailedAttempt =
-          (request?.failedAttempts.p2pAttemptsCount ?? 0) > 0;
-
-        if (
-          !hasP2PFailedAttempt &&
-          this.p2pLoaders.currentLoader.isSegmentLoadedBySomeone(segment) &&
-          (isP2PLoadingRequest ||
-            this.requests.executingP2PCount < simultaneousP2PDownloads)
-        ) {
-          if (!isP2PLoadingRequest) this.loadThroughP2P(segment);
-          continue;
-        }
-
-        if (
+        const canLoadThrougHttp =
           !isInitialHttpWait &&
-          this.requests.executingHttpCount < simultaneousHttpDownloads
-        ) {
-          if (isP2PLoadingRequest) request.abortFromProcessQueue();
-          this.loadThroughHttp(segment);
-          continue;
-        }
+          (request?.failedAttempts.httpAttemptsCount ?? 0) < httpErrorRetries;
 
-        if (
-          !isInitialHttpWait &&
-          this.abortLastHttpLoadingInQueueAfterItem(queue, segment) &&
-          this.requests.executingHttpCount < simultaneousHttpDownloads
-        ) {
-          if (isP2PLoadingRequest) request.abortFromProcessQueue();
-          this.loadThroughHttp(segment);
-          continue;
-        }
+        if (request?.status === "loading") {
+          // High-demand request is loading
 
-        if (isP2PLoadingRequest) continue;
+          const shouldSwitchFromP2PToHttp =
+            canLoadThrougHttp &&
+            request.downloadSource === "p2p" &&
+            (this.requests.executingHttpCount < simultaneousHttpDownloads ||
+              this.abortLastHttpLoadingInQueueAfterItem(queue, segment));
 
-        if (this.requests.executingP2PCount < simultaneousP2PDownloads) {
-          this.loadThroughP2P(segment);
-          continue;
-        }
-
-        if (
-          this.abortLastP2PLoadingInQueueAfterItem(queue, segment) &&
-          this.requests.executingP2PCount < simultaneousP2PDownloads
-        ) {
-          this.loadThroughP2P(segment);
-          continue;
-        }
-      } else if (statuses.isP2PDownloadable) {
-        if (request?.status === "loading") continue;
-
-        if (this.requests.executingP2PCount < simultaneousP2PDownloads) {
-          this.loadThroughP2P(segment);
-        } else if (
-          this.p2pLoaders.currentLoader.isSegmentLoadedBySomeone(segment)
-        ) {
-          if (
-            this.abortLastP2PLoadingInQueueAfterItem(queue, segment) &&
-            this.requests.executingP2PCount < simultaneousP2PDownloads
-          ) {
-            this.loadThroughP2P(segment);
+          if (shouldSwitchFromP2PToHttp) {
+            request.abortFromProcessQueue();
+            this.loadThroughHttp(segment);
           }
+
+          continue;
+        }
+
+        // High-demand request is not loading
+
+        const shouldLoadThroughHttp =
+          canLoadThrougHttp &&
+          (this.requests.executingHttpCount < simultaneousHttpDownloads ||
+            this.abortLastHttpLoadingInQueueAfterItem(queue, segment));
+
+        if (shouldLoadThroughHttp) {
+          this.loadThroughHttp(segment);
+          continue;
+        }
+
+        const canLoadThroughP2P =
+          this.requests.executingP2PCount < simultaneousP2PDownloads ||
+          this.abortLastP2PLoadingInQueueAfterItem(queue, segment);
+
+        if (canLoadThroughP2P) {
+          this.loadThroughP2P(segment);
+        }
+      } else {
+        // Regular requests load via P2P only (random HTTP loading also runs by interval)
+
+        const canLoadThroughP2P =
+          statuses.isP2PDownloadable &&
+          request?.status !== "loading" &&
+          this.requests.executingP2PCount < simultaneousP2PDownloads;
+
+        if (canLoadThroughP2P) {
+          this.loadThroughP2P(segment);
         }
       }
     }

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -301,19 +301,19 @@ export class HybridLoader {
         // Don't abort requests when processing engine request
         // to avoid race condition with aborts in the requests queue
 
-        const canLoadThrougHttp =
+        const canLoadThroughHttp =
           !isInitialHttpWait &&
           (request?.failedAttempts.httpAttemptsCount ?? 0) < httpErrorRetries &&
           this.requests.executingHttpCount < simultaneousHttpDownloads;
 
-        if (canLoadThrougHttp) {
+        if (canLoadThroughHttp) {
           this.loadThroughHttp(segment);
         } else {
-          const canLoadThrougP2P =
+          const canLoadThroughP2P =
             this.p2pLoaders.currentLoader.isSegmentLoadedBySomeone(segment) &&
             this.requests.executingP2PCount < simultaneousP2PDownloads;
 
-          if (canLoadThrougP2P) {
+          if (canLoadThroughP2P) {
             this.loadThroughP2P(segment);
           }
         }
@@ -361,8 +361,9 @@ export class HybridLoader {
         }
 
         const canLoadThroughP2P =
-          this.requests.executingP2PCount < simultaneousP2PDownloads ||
-          this.abortLastP2PLoadingInQueueAfterItem(queue, segment);
+          this.p2pLoaders.currentLoader.isSegmentLoadedBySomeone(segment) &&
+          (this.requests.executingP2PCount < simultaneousP2PDownloads ||
+            this.abortLastP2PLoadingInQueueAfterItem(queue, segment));
 
         if (canLoadThroughP2P) {
           this.loadThroughP2P(segment);


### PR DESCRIPTION
## Summary

Refactors the queue processing logic in `hybrid-loader.ts` for better readability and improved behavior.

### Changes

**Engine request handling:**
- Add P2P fallback path when HTTP is unavailable (during initial delay, slot exhaustion, or retry limit)
- Handle `aborted` request status so engine requests can be retried after queue-initiated aborts
- Extract conditions into named variables for clarity

**High-demand segment processing:**
- Move `succeed` status check before demand-type branching (applies to all segments)
- Simplify P2P-to-HTTP switching logic with clear condition extraction
- Consolidate HTTP slot availability check with abort-and-steal into single condition

**Regular segment processing:**
- Remove aggressive P2P slot stealing (no longer bumps lower-priority P2P loads)
- Simplify to: load via P2P only if a slot is available
- Add descriptive comments explaining the processing logic