### PR TITLE
fix: handle fully loaded segments to prevent stale requests and HTTP 416 errors

### DIFF
--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -200,9 +200,11 @@ export class HttpRequestExecutor {
   }
 
   private handleError(error: unknown, requestControls: RequestControls) {
-    if (error instanceof Error) {
-      if (error.name !== "abort") return;
+    // Abort-initiated errors: the Request already transitioned its own
+    // status via abortFromProcessQueue/abortOnTimeout, nothing to do here.
+    if (this.abortController.signal.aborted) return;
 
+    if (error instanceof Error) {
       const httpLoaderError =
         error instanceof RequestError
           ? (error as RequestError<HttpRequestErrorType>)

--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -102,7 +102,9 @@ export class HttpRequestExecutor {
 
       this.handleResponseHeaders(response);
 
-      if (!response.body) return;
+      if (!response.body) {
+        throw new RequestError("http-error", "Missing response body");
+      }
       requestControls.firstBytesReceived();
 
       const reader = response.body.getReader();

--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -16,7 +16,6 @@ type HttpConfig = Pick<
 >;
 
 export class HttpRequestExecutor {
-  private readonly requestControls: RequestControls;
   private readonly abortController = new AbortController();
   private readonly expectedBytesLength?: number;
   private readonly requestByteRange?: { start: number; end?: number };
@@ -33,6 +32,21 @@ export class HttpRequestExecutor {
     const { byteRange } = this.request.segment;
     if (byteRange) this.requestByteRange = { ...byteRange };
 
+    const startControls = {
+      abort: () => this.abortController.abort("abort"),
+      notReceivingBytesTimeoutMs:
+        this.httpConfig.httpNotReceivingBytesTimeoutMs,
+    };
+
+    const completed = this.request.tryCompleteByLoadedBytes(
+      { downloadSource: "http" },
+      startControls,
+      this.httpConfig.validateHTTPSegment,
+      "http-segment-validation-failed",
+    );
+
+    if (completed) return;
+
     if (request.loadedBytes !== 0) {
       this.requestByteRange = this.requestByteRange ?? { start: 0 };
       this.requestByteRange.start =
@@ -43,18 +57,14 @@ export class HttpRequestExecutor {
         this.request.totalBytes - this.request.loadedBytes;
     }
 
-    this.requestControls = this.request.start(
+    const requestControls = this.request.start(
       { downloadSource: "http" },
-      {
-        abort: () => this.abortController.abort("abort"),
-        notReceivingBytesTimeoutMs:
-          this.httpConfig.httpNotReceivingBytesTimeoutMs,
-      },
+      startControls,
     );
-    void this.fetch();
+    void this.fetch(requestControls);
   }
 
-  private async fetch() {
+  private async fetch(requestControls: RequestControls) {
     const { segment } = this.request;
     try {
       let request = await this.httpConfig.httpRequestSetup?.(
@@ -93,12 +103,11 @@ export class HttpRequestExecutor {
       this.handleResponseHeaders(response);
 
       if (!response.body) return;
-      const { requestControls } = this;
       requestControls.firstBytesReceived();
 
       const reader = response.body.getReader();
       for await (const chunk of readStream(reader)) {
-        this.requestControls.addLoadedChunk(chunk);
+        requestControls.addLoadedChunk(chunk);
         this.onChunkDownloaded(chunk.byteLength, "http");
       }
 
@@ -118,13 +127,13 @@ export class HttpRequestExecutor {
 
       requestControls.completeOnSuccess();
     } catch (error) {
-      this.handleError(error);
+      this.handleError(error, requestControls);
     }
   }
 
   private handleResponseHeaders(response: Response) {
     if (!response.ok) {
-      if (response.status === 406) {
+      if (response.status === 406 || response.status === 416) {
         this.request.clearLoadedBytes();
         throw new RequestError<"http-bytes-mismatch">(
           "http-bytes-mismatch",
@@ -190,7 +199,7 @@ export class HttpRequestExecutor {
     }
   }
 
-  private handleError(error: unknown) {
+  private handleError(error: unknown, requestControls: RequestControls) {
     if (error instanceof Error) {
       if (error.name !== "abort") return;
 
@@ -199,7 +208,7 @@ export class HttpRequestExecutor {
           ? (error as RequestError<HttpRequestErrorType>)
           : new RequestError("http-error", error.message);
 
-      this.requestControls.abortOnError(httpLoaderError);
+      requestControls.abortOnError(httpLoaderError);
     }
   }
 }

--- a/packages/p2p-media-loader-core/src/p2p/peer.ts
+++ b/packages/p2p-media-loader-core/src/p2p/peer.ts
@@ -244,6 +244,20 @@ export class Peer {
     if (this.downloadingContext) {
       throw new Error("Some segment already is downloading");
     }
+
+    const completed = segmentRequest.tryCompleteByLoadedBytes(
+      { downloadSource: "p2p", peerId: this.id },
+      {
+        notReceivingBytesTimeoutMs:
+          this.peerConfig.p2pNotReceivingBytesTimeoutMs,
+        abort: () => void 0,
+      },
+      this.peerConfig.validateP2PSegment,
+      "p2p-segment-validation-failed",
+    );
+
+    if (completed) return;
+
     this.bandwidthCalculator.startLoading();
     this.downloadingContext = {
       request: segmentRequest,

--- a/packages/p2p-media-loader-core/src/requests/request.ts
+++ b/packages/p2p-media-loader-core/src/requests/request.ts
@@ -4,6 +4,7 @@ import {
   CoreEventMap,
   RequestError,
   RequestAbortErrorType,
+  RequestErrorType,
   SegmentWithStream,
   Segment,
 } from "../types.js";
@@ -158,6 +159,97 @@ export class Request {
       throw new Error("Request total bytes value is already set");
     }
     this._totalBytes = value;
+  }
+
+  /**
+   * Checks if all bytes are already loaded and, if so, starts, validates,
+   * and completes the request without making a network request.
+   *
+   * Handles three cases:
+   * - loadedBytes === totalBytes: start → validate → complete (returns true)
+   * - loadedBytes > totalBytes: corrupted state → clearLoadedBytes (returns false)
+   * - otherwise: no-op (returns false)
+   *
+   * The request is started synchronously so that processQueue sees
+   * it as "loading" immediately. Validation runs as fire-and-forget.
+   *
+   * @returns true if the request was started and is being handled,
+   * false if caller should proceed with a normal download.
+   */
+  tryCompleteByLoadedBytes(
+    requestData: StartRequestParameters,
+    controls: {
+      notReceivingBytesTimeoutMs?: number;
+      abort: (errorType: RequestError<RequestAbortErrorType>) => void;
+    },
+    validate?: (
+      url: string,
+      byteRange: Segment["byteRange"],
+      data: ArrayBuffer,
+    ) => Promise<boolean>,
+    validationErrorType?: RequestErrorType,
+  ): boolean {
+    if (!this._totalBytes) return false;
+
+    if (this._loadedBytes > this._totalBytes) {
+      this.clearLoadedBytes();
+      return false;
+    }
+
+    if (this._loadedBytes !== this._totalBytes) return false;
+
+    // Start synchronously so the request is immediately in "loading" status.
+    const requestControls = this.start(requestData, controls);
+
+    // No network bytes will arrive in this path, so disable the timeout
+    // to prevent it from aborting the request during async validation.
+    this.notReceivingBytesTimeout.clear();
+
+    if (validate) {
+      void this.validateAndComplete(
+        requestData.downloadSource,
+        requestControls,
+        validate,
+        validationErrorType,
+      );
+    } else {
+      requestControls.completeOnSuccess();
+    }
+
+    return true;
+  }
+
+  private async validateAndComplete(
+    downloadSource: string,
+    requestControls: RequestControls,
+    validate: (
+      url: string,
+      byteRange: Segment["byteRange"],
+      data: ArrayBuffer,
+    ) => Promise<boolean>,
+    validationErrorType?: RequestErrorType,
+  ) {
+    const isValid = await validate(
+      this.segment.url,
+      this.segment.byteRange,
+      this.data,
+    );
+
+    if (!isValid) {
+      this.logger(
+        `${downloadSource} ${this.segment.externalId} validation failed for already-loaded bytes, clearing`,
+      );
+      this.clearLoadedBytes();
+      requestControls.abortOnError(
+        new RequestError(validationErrorType ?? "abort"),
+      );
+      return;
+    }
+
+    this.logger(
+      `${downloadSource} ${this.segment.externalId} validation passed for already-loaded bytes`,
+    );
+    requestControls.completeOnSuccess();
   }
 
   start(

--- a/packages/p2p-media-loader-core/src/requests/request.ts
+++ b/packages/p2p-media-loader-core/src/requests/request.ts
@@ -229,11 +229,22 @@ export class Request {
     ) => Promise<boolean>,
     validationErrorType?: RequestErrorType,
   ) {
-    const isValid = await validate(
-      this.segment.url,
-      this.segment.byteRange,
-      this.data,
-    );
+    let isValid: boolean;
+    try {
+      isValid = await validate(
+        this.segment.url,
+        this.segment.byteRange,
+        this.data,
+      );
+    } catch (err) {
+      this.logger(
+        `${downloadSource} ${this.segment.externalId} validation threw for already-loaded bytes: ${String(err)}`,
+      );
+      isValid = false;
+    }
+
+    // Request may have been aborted by processQueue while validation ran.
+    if (this._status !== "loading") return;
 
     if (!isValid) {
       this.logger(


### PR DESCRIPTION
## Problem

When a P2P segment download times out after receiving all bytes but before receiving the `SegmentDataSendingCompleted` confirmation, the `Request` stays in `failed` state with `loadedBytes === totalBytes`. On retry via HTTP, this causes an invalid range request (`Range: bytes=N-N` where start equals the total) resulting in **HTTP 416 Range Not Satisfiable** errors, stalling segment delivery.

Closes #523

## Solution

Added `Request.tryCompleteByLoadedBytes()` — a synchronous method that checks byte state before starting any network request:

| Condition | Action |
|---|---|
| `loadedBytes === totalBytes` | Start → validate → complete immediately (**0ms**, no network request) |
| `loadedBytes > totalBytes` | Clear corrupted bytes, proceed with fresh download |
| Otherwise | Proceed with normal download |

Both `HttpRequestExecutor` and `Peer.downloadSegment()` now call this method before initiating network requests.

### Key Design Decisions

- **Synchronous `start()`**: The request transitions to `loading` status immediately, preventing `processQueue` from triggering duplicate downloads in the same microtask.
- **Fire-and-forget validation**: If `validateHTTPSegment`/`validateP2PSegment` is configured, it runs asynchronously after start. On failure, bytes are cleared and the request is aborted with the appropriate error type.
- **DRY**: The three-state logic lives in `Request` and is shared by both HTTP and P2P loaders.

## Testing

Tested with `?test=delay-complete` URL param on the uploading peer (delays `SegmentDataSendingCompleted` by 10s, beyond the 2s `p2pNotReceivingBytesTimeoutMs`). The downloading peer successfully recovers every time:

```
p2p 85568 started
p2p 85568 aborted                           // processQueue switches to HTTP
http 85568 all bytes already loaded (532604) // tryCompleteByLoadedBytes detects full data
http 85568 started                           // synchronous start
http 85568 succeed                           // +0ms, no network fetch
```

- **36+ segments** recovered via early completion in 0-1ms
- **Zero HTTP 416 errors**
- **Zero stalls**
- Both HTTP and P2P early-exit paths verified