### PR TITLE
fix(core): Clear failed attempts when engine explicitly requests a segment

### DIFF
--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -136,6 +136,13 @@ export class HybridLoader {
 
       this.engineRequest?.abort();
       this.engineRequest = engineRequest;
+
+      // If the engine explicitly requests a segment that previously failed during
+      // background pre-fetching, clear its error history so it can be retried.
+      const request = this.requests.get(segment);
+      if (request?.status === "failed") {
+        request.failedAttempts.clear();
+      }
     } catch {
       engineRequest.reject();
     } finally {


### PR DESCRIPTION
### Description
This PR fixes an issue where the loader could permanently stall playback if a segment failed continuously during background pre-fetching. 

When a segment fails too many times in the background (e.g. `httpAttemptsCount >= 3`), it gets marked as `failed` and sits in the `RequestsContainer`. Previously, when the video player playback reached that segment and explicitly requested it via `loadSegment()`, the loader would simply adopt the existing `failed` Request from the background. Since the attempt count was already at the maximum, the request was instantly rejected without any retry attempt, permanently locking the player out from downloading that segment.

This fix ensures that whenever the engine explicitly requests a segment via `loadSegment()`, any existing failed attempts history for that segment is cleared. This guarantees that the engine is always allowed to retry a broken segment from scratch.

### Changes
- Added `request.failedAttempts.clear()` in `hybrid-loader.ts` when processing an engine request.