### PR TITLE
fix: prevent truncated HTTP segments from poisoning P2P cache

### DIFF
--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -136,7 +136,7 @@ export class HttpRequestExecutor {
       ) {
         throw new RequestError(
           "http-bytes-mismatch",
-          "HTTP response truncated",
+          `HTTP response truncated: received ${this.request.loadedBytes} of ${this.request.totalBytes} bytes`,
         );
       }
 

--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -115,17 +115,6 @@ export class HttpRequestExecutor {
         this.onChunkDownloaded(chunk.byteLength, "http");
       }
 
-      const isValid = await this.request.validateData(
-        this.httpConfig.validateHTTPSegment,
-      );
-
-      if (!isValid) {
-        this.request.clearLoadedBytes();
-        throw new RequestError<"http-segment-validation-failed">(
-          "http-segment-validation-failed",
-        );
-      }
-
       // If the HTTP connection drops gracefully but prematurely, fetch yields done: true
       // without throwing an error. We must verify that we received the full segment.
       // If truncated, we throw without clearing loaded bytes to allow the next
@@ -137,6 +126,17 @@ export class HttpRequestExecutor {
         throw new RequestError(
           "http-bytes-mismatch",
           `HTTP response truncated: received ${this.request.loadedBytes} of ${this.request.totalBytes} bytes`,
+        );
+      }
+
+      const isValid = await this.request.validateData(
+        this.httpConfig.validateHTTPSegment,
+      );
+
+      if (!isValid) {
+        this.request.clearLoadedBytes();
+        throw new RequestError<"http-segment-validation-failed">(
+          "http-segment-validation-failed",
         );
       }
 

--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -126,6 +126,20 @@ export class HttpRequestExecutor {
         );
       }
 
+      // If the HTTP connection drops gracefully but prematurely, fetch yields done: true 
+      // without throwing an error. We must verify that we received the full segment.
+      // If truncated, we throw without clearing loaded bytes to allow the next 
+      // download attempt to resume from the current offset using HTTP Range requests.
+      if (
+        this.request.totalBytes !== undefined &&
+        this.request.loadedBytes !== this.request.totalBytes
+      ) {
+        throw new RequestError(
+          "http-bytes-mismatch",
+          "HTTP response truncated",
+        );
+      }
+
       requestControls.completeOnSuccess();
     } catch (error) {
       this.handleError(error, requestControls);

--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -126,9 +126,9 @@ export class HttpRequestExecutor {
         );
       }
 
-      // If the HTTP connection drops gracefully but prematurely, fetch yields done: true 
+      // If the HTTP connection drops gracefully but prematurely, fetch yields done: true
       // without throwing an error. We must verify that we received the full segment.
-      // If truncated, we throw without clearing loaded bytes to allow the next 
+      // If truncated, we throw without clearing loaded bytes to allow the next
       // download attempt to resume from the current offset using HTTP Range requests.
       if (
         this.request.totalBytes !== undefined &&


### PR DESCRIPTION
Resolves #522.

When falling back to HTTP, the segment fetch could be interrupted gracefully (e.g. by a proxy or CDN timeout closing the stream without an explicit TCP error). Previously, the `HttpRequestExecutor` assumed a normal `readStream` completion meant the entire segment was downloaded successfully. It called `completeOnSuccess()` which incorrectly overwrote `totalBytes` with the truncated `loadedBytes` length, marking the partial segment as a successful load.

This truncated segment was then cached, passed to HLS.js (causing 'Found no media in fragment' errors), and announced to the P2P swarm. Other peers would download the truncated data, successfully verify the truncated length reported by the uploader, and also accept the corrupted segment. This caused widespread cache poisoning and player stalls that could not be resolved by seeking.

This fix adds a validation check to `HttpRequestExecutor` that enforces strict byte matching before marking an HTTP segment as fully loaded. If `loadedBytes` does not equal `totalBytes`, an `http-bytes-mismatch` error is thrown without clearing the loaded bytes. This allows the internal retry mechanisms to resume fetching the missing bytes via HTTP Range requests without silently corrupting the P2P swarm cache.