### PR TITLE
feat: add ES2015 IIFE builds for old browsers/TVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ This library makes it possible to build large-scale P2P mesh networks — often 
   - [Core](https://cdn.jsdelivr.net/npm/p2p-media-loader-core@latest/dist/)
   - [Hls.js integration](https://cdn.jsdelivr.net/npm/p2p-media-loader-hlsjs@latest/dist/)
   - [Shaka Player integration](https://cdn.jsdelivr.net/npm/p2p-media-loader-shaka@latest/dist/)
+- IIFE builds CDN (for older browsers and Smart TVs)
+  - [Hls.js integration](https://cdn.jsdelivr.net/npm/p2p-media-loader-hlsjs@latest/dist/p2p-media-loader-hlsjs.iife.min.js)
+  - [Shaka Player integration](https://cdn.jsdelivr.net/npm/p2p-media-loader-shaka@latest/dist/p2p-media-loader-shaka.iife.min.js)
 
 ## Web Browsers Support
 

--- a/api_documentation.md
+++ b/api_documentation.md
@@ -553,3 +553,78 @@ For more examples with npm packages, you may check our [React demo](https://gith
   initPlayer();
 </script>
 ```
+
+## Using P2P Media Loader for older browsers and Smart TVs (IIFE)
+
+For older environments that do not support ES modules (such as older Smart TVs and legacy browsers), you can use the IIFE builds. When using IIFE builds, the library components are exposed through global variables instead of ES module imports.
+
+The global variables are `window.p2pml.hlsjs` and `window.p2pml.shaka`.
+
+### Integrating P2P with raw Hls.js player (IIFE)
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/hls.js@~1/dist/hls.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/p2p-media-loader-hlsjs@latest/dist/p2p-media-loader-hlsjs.iife.min.js"></script>
+
+<script>
+  // Wait for the DOM and scripts to load
+  document.addEventListener("DOMContentLoaded", function () {
+    var videoElement = document.getElementById("video");
+    var streamUrl = "https://example.com/stream.m3u8";
+
+    if (Hls.isSupported()) {
+      // Access the engine from the global p2pml object
+      var HlsJsP2PEngine = window.p2pml.hlsjs.HlsJsP2PEngine;
+
+      var HlsWithP2P = HlsJsP2PEngine.injectMixin(window.Hls);
+      var hls = new HlsWithP2P({
+        p2p: {
+          core: {
+            swarmId: "Optional custom swarm ID for stream",
+            // Other P2P engine config parameters go here
+          },
+        },
+      });
+
+      hls.attachMedia(videoElement);
+      hls.loadSource(streamUrl);
+    }
+  });
+</script>
+```
+
+### Integrating P2P with Shaka Player (IIFE)
+
+```html
+<script src="https://unpkg.com/shaka-player/dist/shaka-player.compiled.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/p2p-media-loader-shaka@latest/dist/p2p-media-loader-shaka.iife.min.js"></script>
+
+<script>
+  // Wait for the DOM and scripts to load
+  document.addEventListener("DOMContentLoaded", async function () {
+    if (shaka.Player.isBrowserSupported()) {
+      var videoElement = document.getElementById("video");
+      var streamUrl = "https://example.com/stream.mpd";
+
+      // Access the engine from the global p2pml object
+      var ShakaP2PEngine = window.p2pml.shaka.ShakaP2PEngine;
+
+      ShakaP2PEngine.registerPlugins();
+      var shakaP2PEngine = new ShakaP2PEngine({
+        p2p: {
+          core: {
+            swarmId: "Optional custom swarm ID for stream",
+            // Other P2P engine config parameters go here
+          },
+        },
+      });
+
+      var player = new shaka.Player();
+      await player.attach(videoElement);
+
+      shakaP2PEngine.bindShakaPlayer(player);
+      await player.load(streamUrl);
+    }
+  });
+</script>
+```

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "prettier": "prettier --write .",
     "type-check": "npx tsc --noEmit",
-    "clean-build": "rimraf dist"
+    "clean:build": "rimraf dist"
   },
   "dependencies": {
     "p2p-media-loader-core": "workspace:*",

--- a/demo/public/modules-demo/hlsjs-iife.html
+++ b/demo/public/modules-demo/hlsjs-iife.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+  <head>
+    <title>HLS.js with P2P Media Loader (IIFE)</title>
+
+    <!-- Load HLS.js -->
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@~1/dist/hls.min.js"></script>
+
+    <!-- Load P2P Media Loader IIFE bundle. This does not use type="module" -->
+    <!-- <script src="./hlsjs/p2p-media-loader-hlsjs.iife.js"></script> -->
+    <script src="./hlsjs/p2p-media-loader-hlsjs.iife.min.js"></script>
+  </head>
+  <body>
+    <h1>P2P Media Loader IIFE Bundle Test</h1>
+    <video id="video" width="640" controls autoplay></video>
+
+    <script>
+      const manifestUri = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8";
+
+      function initApp() {
+        if (Hls.isSupported()) {
+          const video = document.getElementById("video");
+          
+          // The IIFE bundle exports its contents on the global variable defined in vite config
+          const { HlsJsP2PEngine } = window.p2pml.hlsjs;
+          
+          const HlsWithP2P = HlsJsP2PEngine.injectMixin(window.Hls);
+          const hls = new HlsWithP2P();
+          
+          hls.attachMedia(video);
+          hls.on(Hls.Events.ERROR, function (event, data) {
+            console.error("Error code", data.details, "object", data);
+          });
+          
+          try {
+            hls.loadSource(manifestUri);
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          console.error("HLS not supported in this browser.");
+        }
+      }
+
+      document.addEventListener("DOMContentLoaded", initApp);
+    </script>
+  </body>
+</html>

--- a/demo/public/modules-demo/shaka-iife.html
+++ b/demo/public/modules-demo/shaka-iife.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Shaka Player with P2P Media Loader (IIFE)</title>
+
+    <!-- Load Shaka Player -->
+    <script src="https://cdn.jsdelivr.net/npm/shaka-player@~4/dist/shaka-player.compiled.min.js"></script>
+
+    <!-- Load P2P Media Loader IIFE bundle. This does not use type="module" -->
+    <!-- <script src="./shaka/p2p-media-loader-shaka.iife.js"></script> -->
+    <script src="./shaka/p2p-media-loader-shaka.iife.min.js"></script>
+  </head>
+  <body>
+    <h1>P2P Media Loader Shaka IIFE Bundle Test</h1>
+    <video id="video" width="640" controls autoplay></video>
+
+    <script>
+      const manifestUri = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8";
+
+      async function initApp() {
+        if (shaka.Player.isBrowserSupported()) {
+          const video = document.getElementById("video");
+          
+          // The IIFE bundle exports its contents on the global variable defined in vite config
+          const { ShakaP2PEngine } = window.p2pml.shaka;
+          
+          ShakaP2PEngine.registerPlugins();
+          const engine = new ShakaP2PEngine();
+          
+          const player = new shaka.Player();
+          await player.attach(video);
+          
+          player.addEventListener("error", function(event) {
+            console.error("Error code", event.detail.code, "object", event.detail);
+          });
+          
+          engine.bindShakaPlayer(player);
+          
+          try {
+            await player.load(manifestUri);
+          } catch (e) {
+            console.error("Error code", e.code, "object", e);
+          }
+        } else {
+          console.error("Shaka Player not supported in this browser.");
+        }
+      }
+
+      document.addEventListener("DOMContentLoaded", initApp);
+    </script>
+  </body>
+</html>

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "Bundler",

--- a/demo/tsconfig.node.json
+++ b/demo/tsconfig.node.json
@@ -7,5 +7,10 @@
     "emitDeclarationOnly": true
   },
   "types": ["node"],
-  "include": ["vite.config.ts", "eslint.config.ts", "../eslint.common.config.ts", "../eslint.common.react.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "eslint.config.ts",
+    "../eslint.common.config.ts",
+    "../eslint.common.react.config.ts"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:es": "pnpm --filter './packages/**' build:es",
     "build:esm": "pnpm --filter './packages/**' build:esm",
     "build:esm-min": "pnpm --filter './packages/**' build:esm-min",
-    "clean-build": "pnpm --recursive clean-build",
+    "clean:build": "pnpm --recursive clean:build",
     "pack-packages": "pnpm --filter './packages/**' exec -- pnpm pack",
     "lint": "pnpm --recursive lint",
     "prettier": "pnpm --recursive prettier",

--- a/packages/p2p-media-loader-core/package.json
+++ b/packages/p2p-media-loader-core/package.json
@@ -53,7 +53,7 @@
     "build:es": "tsc",
     "prettier": "prettier --write .",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0 --flag unstable_native_nodejs_ts_config",
-    "clean-build": "rimraf lib dist build p2p-media-loader-core-*.tgz",
+    "clean:build": "rimraf lib dist build p2p-media-loader-core-*.tgz",
     "type-check": "npx tsc --noEmit",
     "test": "vitest"
   },

--- a/packages/p2p-media-loader-core/src/bandwidth-calculator.ts
+++ b/packages/p2p-media-loader-core/src/bandwidth-calculator.ts
@@ -58,7 +58,10 @@ export class BandwidthCalculator {
       totalBytes += this.bytes[i];
     }
 
-    const timeDiff = Math.max(lastItemTimestamp - lastCountedTimestamp, MIN_TIME_DIFF_MS);
+    const timeDiff = Math.max(
+      lastItemTimestamp - lastCountedTimestamp,
+      MIN_TIME_DIFF_MS,
+    );
     return (totalBytes * 8000) / timeDiff;
   }
 

--- a/packages/p2p-media-loader-core/src/core.ts
+++ b/packages/p2p-media-loader-core/src/core.ts
@@ -83,7 +83,9 @@ export class Core<TStream extends Stream = Stream> {
   };
   private segmentStorage?: SegmentStorage;
   private readonly webTorrentSocketPool = new WebTorrentSocketPool();
-  private readonly socketPoolLogger = debug("p2pml-core:webtorrent-socket-pool");
+  private readonly socketPoolLogger = debug(
+    "p2pml-core:webtorrent-socket-pool",
+  );
   private mainStreamLoader?: HybridLoader;
   private secondaryStreamLoader?: HybridLoader;
   private streamDetails: StreamDetails = {

--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -110,9 +110,11 @@ export class HttpRequestExecutor {
       requestControls.firstBytesReceived();
 
       const reader = response.body.getReader();
-      for await (const chunk of readStream(reader)) {
-        requestControls.addLoadedChunk(chunk);
-        this.onChunkDownloaded(chunk.byteLength, "http");
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        requestControls.addLoadedChunk(value);
+        this.onChunkDownloaded(value.byteLength, "http");
       }
 
       // If the HTTP connection drops gracefully but prematurely, fetch yields done: true
@@ -227,16 +229,6 @@ export class HttpRequestExecutor {
 
       requestControls.abortOnError(httpLoaderError);
     }
-  }
-}
-
-async function* readStream(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-): AsyncGenerator<Uint8Array> {
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    yield value;
   }
 }
 

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -220,7 +220,14 @@ export class HybridLoader {
           }
           this.requests.remove(request);
 
-          const streamSwarmId = StreamUtils.getStreamSwarmId(this.swarmId, stream);
+          this.logger(
+            `succeed: ${LoggerUtils.getSegmentString(segment)} (byteLength: ${request.data.byteLength})`,
+          );
+
+          const streamSwarmId = StreamUtils.getStreamSwarmId(
+            this.swarmId,
+            stream,
+          );
 
           void this.segmentStorage.storeSegment(
             this.swarmId,

--- a/packages/p2p-media-loader-core/src/p2p/commands/binary-command-creator.ts
+++ b/packages/p2p-media-loader-core/src/p2p/commands/binary-command-creator.ts
@@ -87,6 +87,7 @@ export class BinaryCommandChunksJoiner {
 
 export class BinaryCommandCreator {
   readonly #bytes = new Serialization.ResizableUint8Array();
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
   #resultBuffers: Uint8Array<ArrayBuffer>[] = [];
   #status: "creating" | "completed" = "creating";
   readonly #maxChunkLength: number;
@@ -155,6 +156,7 @@ export class BinaryCommandCreator {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
   getResultBuffers(): Uint8Array<ArrayBuffer>[] {
     if (this.#status === "creating" || !this.#resultBuffers.length) {
       throw new Error("Command is not complete.");

--- a/packages/p2p-media-loader-core/src/p2p/loader.ts
+++ b/packages/p2p-media-loader-core/src/p2p/loader.ts
@@ -25,9 +25,7 @@ export class P2PLoader {
   readonly #swarmId: string;
   readonly #streamSwarmId: string;
   #isAnnounceMicrotaskCreated = false;
-  readonly #webtorrentManagerLogger = debug(
-    "p2pml-core:webtorrent-manager",
-  );
+  readonly #webtorrentManagerLogger = debug("p2pml-core:webtorrent-manager");
 
   #streamManifestUrl: string;
   readonly #stream: StreamWithSegments;
@@ -48,7 +46,6 @@ export class P2PLoader {
     eventTarget: EventTarget<EventTargetMap>,
     onSegmentAnnouncement: () => void,
   ) {
-    
     this.#streamManifestUrl = streamManifestUrl;
     this.#stream = stream;
     this.#requests = requests;

--- a/packages/p2p-media-loader-core/src/p2p/loaders-container.ts
+++ b/packages/p2p-media-loader-core/src/p2p/loaders-container.ts
@@ -102,7 +102,10 @@ export class P2PLoadersContainer {
       swarmId,
       this.#currentLoaderItem.stream,
     );
-    const ids = this.#segmentStorage.getStoredSegmentIds(swarmId, streamSwarmId);
+    const ids = this.#segmentStorage.getStoredSegmentIds(
+      swarmId,
+      streamSwarmId,
+    );
     if (!ids.length) this.#destroyAndRemoveLoader(this.#currentLoaderItem);
     else this.#setLoaderDestroyTimeout(this.#currentLoaderItem);
 

--- a/packages/p2p-media-loader-core/src/p2p/peer-protocol.ts
+++ b/packages/p2p-media-loader-core/src/p2p/peer-protocol.ts
@@ -103,6 +103,7 @@ export class PeerProtocol {
   }
 
   async splitSegmentDataToChunksAndUploadAsync(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
     data: ArrayBuffer | ArrayBufferView<ArrayBuffer>,
     requestId: number,
   ) {

--- a/packages/p2p-media-loader-core/src/p2p/peer.ts
+++ b/packages/p2p-media-loader-core/src/p2p/peer.ts
@@ -45,7 +45,7 @@ export class Peer {
   readonly #eventHandlers: PeerEventHandlers;
   readonly #peerConfig: PeerConfig;
 
-  // Required to suppress TypeScrypt error: Unnecessary conditional, value is always falsy
+  // Required to suppress TypeScript error: Unnecessary conditional, value is always falsy
   #checkIsDestroyed() {
     return this.#isDestroyed;
   }
@@ -58,7 +58,6 @@ export class Peer {
     peerConfig: PeerConfig,
     readonly eventTarget: EventTarget<CoreEventMap>,
   ) {
-    
     this.#closeConnection = closeConnection;
     this.#eventHandlers = eventHandlers;
     this.#peerConfig = peerConfig;
@@ -304,11 +303,14 @@ export class Peer {
   async uploadSegmentData(
     segment: SegmentWithStream,
     requestId: number,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
     data: ArrayBuffer | ArrayBufferView<ArrayBuffer>,
   ) {
     if (this.#isDestroyed) return;
     const { externalId } = segment;
-    this.#logger(`send segment ${segment.externalId} to ${this.id}`);
+    this.#logger(
+      `send segment ${segment.externalId} to ${this.id} (byteLength: ${data.byteLength})`,
+    );
     const command: Command.PeerSendSegmentCommand = {
       c: PeerCommandType.SegmentData,
       i: externalId,

--- a/packages/p2p-media-loader-core/src/segment-storage/segment-memory-storage.ts
+++ b/packages/p2p-media-loader-core/src/segment-storage/segment-memory-storage.ts
@@ -224,9 +224,7 @@ export class SegmentMemoryStorage implements SegmentStorage {
     );
   }
 
-  setSegmentChangeCallback(
-    callback: ((streamId: string) => void) | undefined,
-  ) {
+  setSegmentChangeCallback(callback: ((streamId: string) => void) | undefined) {
     this.segmentChangeCallback = callback;
   }
 

--- a/packages/p2p-media-loader-core/src/utils/utils.ts
+++ b/packages/p2p-media-loader-core/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import { CommonCoreConfig, CoreConfig, StreamConfig } from "../types.js";
 
-export function getControlledPromise<T = void>() {
+export function getPromiseWithResolvers<T = void>() {
   let resolve: (value: T) => void;
   let reject: (reason?: unknown) => void;
   const promise = new Promise<T>((res, rej) => {

--- a/packages/p2p-media-loader-core/src/webtorrent/data-channel-sender.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/data-channel-sender.ts
@@ -1,4 +1,5 @@
 const MAX_BUFFERED_AMOUNT = 64 * 1024; // 64 KB, matching simple-peer
+import { getPromiseWithResolvers } from "../utils/utils.js";
 import { getRTCErrorMessage } from "./utils.js";
 
 export class DataChannelSender {
@@ -10,6 +11,7 @@ export class DataChannelSender {
   ) {}
 
   async sendData(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
     data: ArrayBuffer | ArrayBufferView<ArrayBuffer>,
     onChunkSent?: (chunkSize: number) => void,
   ): Promise<void> {
@@ -22,12 +24,7 @@ export class DataChannelSender {
 
     this.channel.bufferedAmountLowThreshold = MAX_BUFFERED_AMOUNT;
 
-    let resolve!: () => void;
-    let reject!: (reason?: unknown) => void;
-    const promise = new Promise<void>((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
+    const { promise, resolve, reject } = getPromiseWithResolvers();
 
     let offset = 0;
     let isSettled = false;

--- a/packages/p2p-media-loader-core/src/webtorrent/data-channel-sender.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/data-channel-sender.ts
@@ -1,6 +1,7 @@
-const MAX_BUFFERED_AMOUNT = 64 * 1024; // 64 KB, matching simple-peer
 import { getPromiseWithResolvers } from "../utils/utils.js";
 import { getRTCErrorMessage } from "./utils.js";
+
+const MAX_BUFFERED_AMOUNT = 64 * 1024; // 64 KB, matching simple-peer
 
 export class DataChannelSender {
   #currentSendContext?: { cancel: () => void };

--- a/packages/p2p-media-loader-core/src/webtorrent/websocket-client/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/websocket-client/index.ts
@@ -96,6 +96,7 @@ export class WebSocketClient {
   }
 
   public send(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
     data: string | ArrayBuffer | Blob | ArrayBufferView<ArrayBuffer>,
   ): void {
     if (this.#state !== "connected" || !this.#ws) {

--- a/packages/p2p-media-loader-core/src/webtorrent/websocket-client/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/websocket-client/spec.md
@@ -8,10 +8,10 @@ A robust, universal WebSocket client. It automatically maintains the connection 
 
 ```typescript
 interface WebSocketClientConfig {
-  url: string;                  // The WebSocket endpoint to connect to
-  initialDelay?: number;        // The initial wait time before the first reconnection attempt. Default: 1000 (1s)
-  maxDelay?: number;            // The maximum wait time between reconnection attempts. Default: 30000 (30s)
-  jitterMultiplier?: number;    // A multiplier used to add randomness to the delay. Default: 0.2
+  url: string; // The WebSocket endpoint to connect to
+  initialDelay?: number; // The initial wait time before the first reconnection attempt. Default: 1000 (1s)
+  maxDelay?: number; // The maximum wait time between reconnection attempts. Default: 30000 (30s)
+  jitterMultiplier?: number; // A multiplier used to add randomness to the delay. Default: 0.2
 }
 ```
 
@@ -46,4 +46,3 @@ The client implements an `EventTarget` system emitting the following lifecycle e
    `jitter = baseDelay * jitterMultiplier`
    `delay = max(0, baseDelay + random(-jitter, jitter))`
 2. **Binary Compatibility**: Configures `binaryType = 'arraybuffer'` on the underlying native WebSocket to ensure compatible and efficient handling of arbitrary binary protocols.
-

--- a/packages/p2p-media-loader-core/src/webtorrent/websocket-client/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/websocket-client/spec.md
@@ -2,38 +2,48 @@
 
 A robust, universal WebSocket client. It automatically maintains the connection and reconnects using Exponential Backoff and Jitter.
 
-## Constructor / Configuration Options
+## 1. Public API
 
-The client should be configurable upon instantiation:
+### Constructor Configuration
 
-- `url` (string): The WebSocket endpoint to connect to.
-- `initialDelay` (number, ms): The initial wait time before the first reconnection attempt. Default: `1000`.
-- `maxDelay` (number, ms): The maximum wait time between reconnection attempts. Default: `30000`.
-- `jitterMultiplier` (number): A multiplier used to add randomness to the delay, preventing thundering herd problems. Default: `0.2`.
+```typescript
+interface WebSocketClientConfig {
+  url: string;                  // The WebSocket endpoint to connect to
+  initialDelay?: number;        // The initial wait time before the first reconnection attempt. Default: 1000 (1s)
+  maxDelay?: number;            // The maximum wait time between reconnection attempts. Default: 30000 (30s)
+  jitterMultiplier?: number;    // A multiplier used to add randomness to the delay. Default: 0.2
+}
+```
 
-## Properties
+### Properties
 
-Expose the following state to consumers:
+- `state` (`'connecting' | 'connected' | 'reconnecting' | 'disconnected' | 'disposed'`): Read-only getter returning the current state of the client.
 
-- `state` (enum/string): Current state of the client (`'connecting' | 'connected' | 'reconnecting' | 'disconnected' | 'disposed'`).
+### Methods
 
-## Methods
+- `connect(): void`: Initiates the WebSocket connection.
+- `send(data: string | ArrayBuffer | Blob | ArrayBufferView): void`: Sends data over the WebSocket. Must support binary data. Throws an error if called when not connected.
+- `dispose(): void`: Completely tears down the client, clears callbacks, stops all timers, closes the socket, clears event listeners, and prevents future automatic reconnections.
+- `addEventListener<K extends keyof WebSocketClientEventMap>(eventName: K, listener: WebSocketClientEventMap[K]): void`: Registers an event listener.
+- `removeEventListener<K extends keyof WebSocketClientEventMap>(eventName: K, listener: WebSocketClientEventMap[K]): void`: Removes a registered event listener.
 
-- `connect()`: Initiates the WebSocket connection.
-- `send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void`: Sends data over the WebSocket. Must support binary data.
-- `dispose()`: Completely tears down the client, stops all timers, closes the socket, and prevents future automatic reconnections.
+### Events
 
-## Events
+The client implements an `EventTarget` system emitting the following lifecycle events:
 
-The client should emit the following lifecycle events:
+- `connected` (payload: `void`): Fired when the WebSocket connection is successfully established.
+- `disconnected` (payload: `void`): Fired when the connection is lost (or deliberately closed).
+- `reconnecting` (payload: `void`): Fired when a reconnection attempt is scheduled.
+- `error` (payload: `Event`): Fired when a WebSocket error occurs.
+- `message` (payload: `ArrayBuffer | string`): Fired when a message is received from the server.
 
-- `connected`: Fired when the WebSocket connection is successfully established.
-- `disconnected`: Fired when the connection is lost (or deliberately closed).
-- `reconnecting`: Fired when a reconnection attempt is scheduled.
-- `error`: Fired when a WebSocket error occurs.
-- `message`: Fired when a message is received from the server.
+---
 
-## Architectural Behaviors
+## 2. Architectural Behaviors
 
-1. **Exponential Backoff & Jitter**: Reconnection delays increase exponentially with a random jitter factor to avoid overwhelming the server upon restart.
-2. **Binary Compatibility**: Configures `binaryType = 'arraybuffer'` on the underlying socket to ensure compatibility with arbitrary binary protocols.
+1. **Exponential Backoff & Jitter**: Reconnection delays increase exponentially with a random jitter factor to avoid overwhelming the server upon restart. The delay is calculated as:
+   `baseDelay = min(initialDelay * 2^backoffCount, maxDelay)`
+   `jitter = baseDelay * jitterMultiplier`
+   `delay = max(0, baseDelay + random(-jitter, jitter))`
+2. **Binary Compatibility**: Configures `binaryType = 'arraybuffer'` on the underlying native WebSocket to ensure compatible and efficient handling of arbitrary binary protocols.
+

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
@@ -10,6 +10,7 @@ export type WebTorrentClientEventMap = {
     connection: RTCPeerConnection;
     channel?: RTCDataChannel;
   }) => void;
+  peerSignalingFailed: (event: { peerId: string; error: string }) => void;
   warning: (warning: string) => void;
   error: (error: string) => void;
 };
@@ -454,8 +455,9 @@ export class WebTorrentClient {
 
       const sdp = pc.localDescription;
       if (!sdp) {
-        pc.close();
-        return;
+        throw new Error(
+          "Failed to get local description after ICE gathering",
+        );
       }
 
       const payload = {
@@ -470,6 +472,10 @@ export class WebTorrentClient {
       this.#wsClient.send(JSON.stringify(payload));
     } catch (err) {
       pc.close();
+      this.#eventTarget.dispatchEvent("peerSignalingFailed", {
+        peerId: remotePeerId,
+        error: err instanceof Error ? err.message : String(err),
+      });
       throw err;
     } finally {
       this.#negotiatingConnections.delete(pc);
@@ -508,6 +514,10 @@ export class WebTorrentClient {
       if (this.#checkDestroyed()) return;
     } catch (err) {
       pending.connection.close();
+      this.#eventTarget.dispatchEvent("peerSignalingFailed", {
+        peerId: remotePeerId,
+        error: err instanceof Error ? err.message : String(err),
+      });
       throw err;
     } finally {
       this.#negotiatingConnections.delete(pending.connection);

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
@@ -455,9 +455,7 @@ export class WebTorrentClient {
 
       const sdp = pc.localDescription;
       if (!sdp) {
-        throw new Error(
-          "Failed to get local description after ICE gathering",
-        );
+        throw new Error("Failed to get local description after ICE gathering");
       }
 
       const payload = {

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
@@ -7,8 +7,9 @@ A lightweight WebTorrent signaling client that handles the WebSocket tracker pro
 The `WebTorrentClient` acts as a signaling layer using the `WebSocketClient` under the hood. It connects to a single standard WebTorrent tracker, exchanges SDP offers and answers, manages ICE candidate gathering, and returns negotiating (not yet connected) `RTCPeerConnection` and `RTCDataChannel` instances to consumers.
 
 **Key Design Decisions:**
+
 1. **Strictly Browser Implementation**: Uses native browser `RTCPeerConnection` APIs without Node.js polyfills or dependencies.
-2. **Single Responsibility (SRP)**: Each instance manages exactly **one** WebSocket connection to a **single** tracker. 
+2. **Single Responsibility (SRP)**: Each instance manages exactly **one** WebSocket connection to a **single** tracker.
 3. **Early Deduplication**: To prevent duplicate peer connections across multiple tracker clients, it accepts a `claimPeer` callback to attempt to lock a `peer_id` for signaling, successfully deduplicating at the earliest possible stage.
 4. **Negotiate and Hand-Off**: The client handles WebRTC SDP signaling. The exact moment signaling finishes, it emits the negotiating objects to a higher layer (e.g., Swarm Manager) which takes ownership, waits for the connection to open, and handles the BitTorrent wire protocol.
 5. **Data Channel Configuration**: Matches the default behavior of the `bittorrent-tracker` (and `simple-peer`) npm packages, which create reliable, ordered Data Channels (empty `RTCDataChannelInit` config) unless explicitly overridden.
@@ -19,21 +20,22 @@ The `WebTorrentClient` acts as a signaling layer using the `WebSocketClient` und
 ## 1. Public API
 
 ### Constructor Configuration
+
 ```typescript
 interface WebTorrentClientConfig {
-  wsClient: WebSocketClient;    // The underlying WebSocket client
-  infoHash: string;             // 20-byte hex string representing the torrent
-  peerId: string;               // 20-byte hex string representing this client
+  wsClient: WebSocketClient; // The underlying WebSocket client
+  infoHash: string; // 20-byte hex string representing the torrent
+  peerId: string; // 20-byte hex string representing this client
   rtcConfig?: RTCConfiguration; // Optional custom STUN/TURN server configuration
   channelConfig?: RTCDataChannelInit; // Optional Data Channel overrides
-  offerTimeout?: number;        // Time (in ms) to keep unanswered offers before destroying them. Default: 50000 (50s).
-  offersCount?: number;         // Maximum number of offers to generate per announce interval. Default: 5.
-  
+  offerTimeout?: number; // Time (in ms) to keep unanswered offers before destroying them. Default: 50000 (50s).
+  offersCount?: number; // Maximum number of offers to generate per announce interval. Default: 5.
+
   // Callback invoked when a peer_id is discovered via an offer or answer.
   // Attempts to claim the peer for the specified timeout duration.
   // Return true to accept and connect, false if the peer is already claimed/connected.
-  claimPeer?: (peerId: string, timeout: number) => boolean; 
-  
+  claimPeer?: (peerId: string, timeout: number) => boolean;
+
   // Callback invoked before every announce to determine if new offers should be generated.
   // Return false to stop generating offers (numwant: 0), while still answering incoming offers.
   shouldGenerateOffers?: () => boolean;
@@ -59,22 +61,28 @@ interface WebTorrentClientConfig {
 ## 2. Architecture & Lifecycle
 
 ### Early Deduplication (The `claimPeer` Hook)
+
 Because the higher layer (e.g., Peer Manager) may spin up multiple `WebTorrentClient` instances for different public trackers, the same remote peer will likely be discovered multiple times. The client uses the injected `claimPeer` to deduplicate aggressively:
 
 1. **When Receiving an Offer:** The tracker JSON includes the remote `peer_id`. The client immediately calls `claimPeer(peer_id, offerTimeout)`. If it returns `false`, the client **ignores the JSON message entirely** and does not create an `RTCPeerConnection`.
 2. **When Receiving an Answer:** The tracker forwards an `answer` to a pending offer we sent. The JSON includes the remote `peer_id`. The client calls `claimPeer(peer_id, offerTimeout)`. If it returns `false`, the client **immediately closes** the pending `RTCPeerConnection` and discards the answer.
 
 ### Message Validation
+
 Before processing offers and answers, the client validates incoming messages:
+
 1. **`info_hash` Check**: If the message includes an `info_hash` field that does not match the client's configured `infoHash`, the entire message is silently discarded. This prevents cross-talk when WebSocket connections are shared across multiple torrents.
 2. **Self-Peer Check**: If the message's `peer_id` matches our own `peerId`, it is silently discarded. This prevents the client from attempting to connect to itself.
 3. **Runtime Type Checks**: All fields from the untrusted JSON are validated with `typeof` checks before use. No unsafe `as` casts are applied to the raw parsed data.
 
 ### WebTorrent Tracker Protocol (Detailed Message Flow)
+
 The client communicates via JSON messages over the `WebSocketClient`. Below is the exact format of the payloads exchanged between the client and the tracker.
 
 #### 1. Announcing & Sending Offers (Client -> Tracker)
+
 Periodically (based on the tracker's `interval`), or when first connecting, the client sends an `announce` action. If the client wants to initiate connections (and `shouldGenerateOffers` returns `true`), it gathers ICE candidates and includes an array of `offers`. If `shouldGenerateOffers` returns `false`, it sends `"numwant": 0` and an empty `"offers": []` array to maintain presence in the swarm without incurring offer-generation overhead.
+
 ```json
 {
   "action": "announce",
@@ -95,6 +103,7 @@ Periodically (based on the tracker's `interval`), or when first connecting, the 
 ```
 
 #### 2. Tracker Announce Response (Tracker -> Client)
+
 The tracker replies to the announce with swarm statistics. Upon receiving this message, the client reads the `interval` property and schedules the next announce using an internal `setInterval`. To prevent unnecessarily resetting the announce loop, the interval timer is only cleared and restarted if the tracker explicitly changes the `interval` value.
 
 ```json
@@ -109,12 +118,15 @@ The tracker replies to the announce with swarm statistics. Upon receiving this m
 ```
 
 #### 3. Tracker Error & Warning Responses (Tracker -> Client)
+
 Trackers may respond with errors (which usually mean the announce failed entirely) or warnings. They follow this specific format:
+
 ```json
 {
   "failure reason": "Invalid info_hash"
 }
 ```
+
 ```json
 {
   "warning message": "Rate limited, please slow down"
@@ -122,7 +134,9 @@ Trackers may respond with errors (which usually mean the announce failed entirel
 ```
 
 #### 4. Receiving an Offer (Tracker -> Client)
+
 When another peer generates an offer and the tracker routes it to us, it arrives in this format:
+
 ```json
 {
   "action": "announce",
@@ -134,7 +148,9 @@ When another peer generates an offer and the tracker routes it to us, it arrives
 ```
 
 #### 5. Sending an Answer (Client -> Tracker)
+
 When the client accepts an incoming offer, it generates an answer and sends it back to the tracker. Note the inclusion of `to_peer_id` to tell the tracker exactly who should receive it.
+
 ```json
 {
   "action": "announce",
@@ -147,7 +163,9 @@ When the client accepts an incoming offer, it generates an answer and sends it b
 ```
 
 #### 6. Receiving an Answer (Tracker -> Client)
+
 When a remote peer accepts an offer we previously sent, the tracker routes their answer back to us.
+
 ```json
 {
   "action": "announce",
@@ -159,13 +177,17 @@ When a remote peer accepts an offer we previously sent, the tracker routes their
 ```
 
 ### WebRTC Connection Flow (Offers & Answers)
+
 Standard WebTorrent signaling **does not use Trickle ICE**. All ICE candidates must be gathered and bundled into a single SDP before sending it to the tracker.
 
 #### ICE Gathering Timeout
+
 ICE gathering can stall indefinitely if STUN/TURN servers are unreachable or the network is offline. To prevent this, the client enforces a **5-second timeout** on ICE gathering (matching `simple-peer`'s `ICECOMPLETE_TIMEOUT`). If gathering does not complete within 5 seconds, the promise is rejected and the caller closes the `RTCPeerConnection`. After any async ICE wait, the client also checks the `destroyed` flag to avoid acting on a torn-down instance.
 
 #### Initiating Connections (Sending Offers)
+
 When generating offers, we do **not** know which peer will receive them. All offers are generated **in parallel** (via `Promise.allSettled`) to avoid sequential ICE gathering latency — reducing worst-case announce delay from `offersCount × ICE_TIMEOUT` to a single `ICE_TIMEOUT`.
+
 1. For each offer slot, the client concurrently creates a new `RTCPeerConnection` and `RTCDataChannel`.
 2. It creates an SDP offer, waits for ICE gathering, and bundles the SDP.
 3. It generates a random alphanumeric `offer_id` (e.g., 20 characters) to ensure safe string handling during JSON serialization/deserialization.
@@ -174,6 +196,7 @@ When generating offers, we do **not** know which peer will receive them. All off
 6. Once all parallel offer tasks settle, the successfully created offers are collected and attached to a single tracker `announce` payload. Failed offers are discarded (with an error event dispatched). (The Swarm Manager is **not** involved yet, because we don't have a `peer_id`).
 
 #### Receiving Offers
+
 1. The tracker sends an incoming `offer` originating from another peer. This payload **does** contain their `peer_id`.
 2. **Deduplication Check**: Call `claimPeer(peer_id, offerTimeout)`. Abort if `false`.
 3. The client creates a new `RTCPeerConnection` and calls `setRemoteDescription`.
@@ -181,6 +204,7 @@ When generating offers, we do **not** know which peer will receive them. All off
 5. **Immediate Hand-Off**: Signaling is complete. The client emits the `peerSignaled` event with `{ peerId, connection }` (no `channel` because it hasn't been established yet). The client forgets about this connection.
 
 #### Receiving Answers
+
 1. The tracker forwards an `answer` SDP to an `offer_id` we previously sent. This payload now reveals the remote `peer_id`.
 2. **Deduplication Check**: We finally know who answered! Call `claimPeer(peer_id, offerTimeout)`.
 3. If `claimPeer` returns `false` (we are already connected to them via another route), we look up the pending `RTCPeerConnection` by `offer_id`, immediately call `.close()`, clear the timeout, delete it, and abort.
@@ -188,9 +212,11 @@ When generating offers, we do **not** know which peer will receive them. All off
 5. **Immediate Hand-Off**: Signaling is complete. The client removes the connection from `pendingOffers` and emits the `peerSignaled` event with `{ peerId, connection, channel }`.
 
 ### Hand-Off (Strict SRP)
-To maintain strict Single Responsibility, the `WebTorrentClient`'s job ends the exact millisecond the SDP negotiation finishes. It does **not** wait for the Data Channel to open, nor does it monitor ICE connection states. It emits the `peerSignaled` event and drops its internal reference. 
+
+To maintain strict Single Responsibility, the `WebTorrentClient`'s job ends the exact millisecond the SDP negotiation finishes. It does **not** wait for the Data Channel to open, nor does it monitor ICE connection states. It emits the `peerSignaled` event and drops its internal reference.
 
 The upper Peer Manager receives the negotiating objects and takes full responsibility for:
+
 1. If `channel` is provided (initiator), listening to `channel.onopen`.
 2. If `channel` is undefined (receiver), listening to `connection.ondatachannel` and then its `onopen` event.
 3. Listening to `connection.oniceconnectionstatechange` to detect failures.

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
@@ -40,15 +40,17 @@ interface WebTorrentClientConfig {
 }
 ```
 
-### Properties
-- `state` (`'disconnected' | 'connecting' | 'connected' | 'error'`): Current connection state to the single tracker.
-
 ### Methods
+
 - `start(): void`: Begins the `announce` loop if the injected `WebSocketClient` is already connected, or waits for it to connect. It does not call `connect()` on the injected client.
-- `destroy(): void`: Complete teardown. Sends a final `event: "stopped"` announce to the tracker (if connected), clears all pending offers and timers, and removes all event listeners. Does NOT dispose the `WebSocketClient` as it may be pooled.
+- `destroy(): void`: Complete teardown. Sends a final `event: "stopped"` announce to the tracker (if connected), clears all pending offers and timers, removes all event listeners, and disposes the abort controllers. Does NOT dispose the `WebSocketClient` as it may be pooled.
+- `addEventListener<K extends keyof WebTorrentClientEventMap>(eventName: K, listener: WebTorrentClientEventMap[K]): void`: Registers an event listener.
+- `removeEventListener<K extends keyof WebTorrentClientEventMap>(eventName: K, listener: WebTorrentClientEventMap[K]): void`: Removes a registered event listener.
 
 ### Events
+
 - `peerSignaled` (payload: `{ peerId: string, connection: RTCPeerConnection, channel?: RTCDataChannel }`): Fired the exact moment WebRTC SDP signaling is complete. The Swarm Manager takes immediate ownership. Note: `channel` is only provided if we initiated the connection. If we received the offer, the Swarm Manager must listen for the `ondatachannel` event on the connection.
+- `peerSignalingFailed` (payload: `{ peerId: string, error: string }`): Fired if WebRTC SDP negotiation fails after a peer has been claimed (e.g., ICE gathering timeout or SDP application error), allowing the manager to release the claim.
 - `warning` (payload: `string`): Fired if the tracker returns a warning.
 - `error` (payload: `string`): Fired if the tracker returns an error, or if the underlying WebSocket encounters a failure.
 

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
@@ -479,10 +479,8 @@ export class WebTorrentManager {
       }
     };
 
-    const onChannelClose = () =>
-      onDisconnect("Data channel closed", false);
-    const onChannelClosing = () =>
-      onDisconnect("Data channel closing", false);
+    const onChannelClose = () => onDisconnect("Data channel closed", false);
+    const onChannelClosing = () => onDisconnect("Data channel closing", false);
     const onChannelError = (event: Event) => {
       const msg = getRTCErrorMessage(event, "Data channel error");
       onDisconnect(`Data channel error: ${msg}`, true);

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
@@ -163,6 +163,22 @@ export class WebTorrentManager {
           );
         };
 
+        const onPeerSignalingFailed = (event: {
+          peerId: string;
+          error: string;
+        }) => {
+          const peer = this.#connectingPeers.get(event.peerId);
+          if (peer?.status === "signaling") {
+            clearTimeout(peer.timeoutId);
+            this.#connectingPeers.delete(event.peerId);
+            this.#eventTarget.dispatchEvent("peerConnectFailed", {
+              peerId: event.peerId,
+              trackerUrl: url,
+              error: `Signaling failed: ${event.error}`,
+            });
+          }
+        };
+
         const onWarning = (warning: string) => {
           this.#eventTarget.dispatchEvent("warning", {
             trackerUrl: url,
@@ -175,11 +191,16 @@ export class WebTorrentManager {
         };
 
         client.addEventListener("peerSignaled", onPeerSignaled);
+        client.addEventListener("peerSignalingFailed", onPeerSignalingFailed);
         client.addEventListener("warning", onWarning);
         client.addEventListener("error", onError);
 
         const cleanupListeners = () => {
           client.removeEventListener("peerSignaled", onPeerSignaled);
+          client.removeEventListener(
+            "peerSignalingFailed",
+            onPeerSignalingFailed,
+          );
           client.removeEventListener("warning", onWarning);
           client.removeEventListener("error", onError);
         };

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/spec.md
@@ -10,7 +10,7 @@ While a `WebTorrentClient` handles signaling for exactly **one** tracker, a real
 1. **WebSocket Pooling**: Utilizes the `WebTorrentSocketPool` to share `WebSocketClient` connections. If multiple `WebTorrentManager` instances (for different `infoHash`es) use the same tracker URL, they will safely share the same underlying WebSocket.
 2. **Aggregating Trackers**: Spins up and manages a `WebTorrentClient` for each configured tracker URL.
 3. **Peer Uniqueness & Deduplication**: Ensures that the same remote peer is not connected multiple times, even if discovered across multiple trackers simultaneously.
-4. **Peer Management**: Tracks active/negotiating peers, waits for Data Channels to open before emitting them, allows the upper layer to query connected peers, and provides an API to force-close a peer connection.
+4. **Peer Management**: Tracks active/negotiating peers, waits for Data Channels to open before emitting them, and provides a clean API to close individual peer connections.
 
 ---
 
@@ -25,24 +25,23 @@ interface WebTorrentManagerConfig {
   trackerUrls: string[];        // Array of WebSocket tracker URLs to connect to
   rtcConfig?: RTCConfiguration; // WebRTC STUN/TURN configuration
   channelConfig?: RTCDataChannelInit; // Data Channel configuration
-  
-  // Optional shared socket pool. If not provided, the manager can instantiate its own 
-  // or rely on a global pool passed down from the engine.
-  socketPool: WebTorrentSocketPool; 
+  socketPool: WebTorrentSocketPool; // Shared socket pool
 }
 ```
 
 ### Methods
 
 - `start(): void`: Acquires sockets from the pool, instantiates the `WebTorrentClient`s, and calls `start()` on all of them.
-- `destroy(): void`: Destroys all child `WebTorrentClient` instances, releases all sockets back to the pool, and clears the known peers list.
+- `destroy(): void`: Destroys all child `WebTorrentClient` instances, releases all sockets back to the pool, closes all active and connecting peer connections, dispatches `peerDisconnected` events for all connected peers, and clears all internal event listeners.
+- `addEventListener<K extends keyof WebTorrentManagerEventMap>(eventName: K, listener: WebTorrentManagerEventMap[K]): void`: Registers an event listener.
+- `removeEventListener<K extends keyof WebTorrentManagerEventMap>(eventName: K, listener: WebTorrentManagerEventMap[K]): void`: Removes a registered event listener.
 
 ### Events
 
-The Manager aggregates events from all child clients and forwards them.
+The Manager aggregates events from all child clients and forwards/handles them.
 
 - `peerConnected` (payload: `{ peerId: string, connection: RTCPeerConnection, channel: RTCDataChannel, trackerUrl: string, close: (error?: string) => void }`): Fired when a peer finishes WebRTC signaling on *any* tracker and its Data Channel is successfully opened.
-- `peerDisconnected` (payload: `{ peerId: string, error?: string }`): Fired when a fully connected peer is closed, either due to an unexpected disconnect (e.g. network loss) or a manual call to `peer.close()`.
+- `peerDisconnected` (payload: `{ peerId: string, reason: string, isError: boolean }`): Fired when a fully connected peer is closed, either due to an unexpected disconnect (e.g., network loss), manager destruction, or a manual call to the peer's `close` callback.
 - `peerConnectFailed` (payload: `{ peerId: string, trackerUrl: string, error: string }`): Fired if a signaled peer fails to connect or its data channel fails to open.
 - `warning` (payload: `{ trackerUrl: string, warning: string }`): Aggregated tracker warnings.
 - `error` (payload: `{ trackerUrl: string, error: string }`): Aggregated tracker errors (both WebSocket level and WebTorrent level).
@@ -53,47 +52,66 @@ The Manager aggregates events from all child clients and forwards them.
 
 ### Socket Pool Integration
 For each URL in `trackerUrls`, the Manager calls `socketPool.acquire(url)`. This returns an object containing the `client` (a `WebSocketClient`) and a `release()` closure.
-The Manager then constructs a `WebTorrentClient`, passing the acquired `WebSocketClient` into its configuration. 
+The Manager then constructs a `WebTorrentClient`, passing the acquired `WebSocketClient` into its configuration.
 When the Manager is destroyed, it calls `client.destroy()` on the `WebTorrentClient`s, and then invokes the `release()` closure for each socket to return it to the pool.
 
 ### Peer Deduplication across Trackers
-Because a user might be active on `wss://tracker1.com` and `wss://tracker2.com`, both trackers might send us the same remote `peer_id`. 
+Because a user might be active on `wss://tracker1.com` and `wss://tracker2.com`, both trackers might send us the same remote `peer_id`.
 To adhere to the Single Source of Truth principle, the `WebTorrentManager` avoids managing a separate set of known peers. Instead, it checks its existing collections of connected and connecting peers.
-It passes a bound `claimPeer` callback into every `WebTorrentClient` it creates:
+It passes a bound `#claimPeer` callback into every `WebTorrentClient` it creates:
 
 ```typescript
-const claimPeer = (remotePeerId: string, timeout: number) => {
-  if (this.connectingPeers.has(remotePeerId) || this.connectedPeers.has(remotePeerId)) {
-    return false; // Already negotiating or connected via another tracker
+#claimPeer = (remotePeerId: string, timeout: number): boolean => {
+  if (this.#destroyed) return false;
+
+  if (
+    this.#connectingPeers.has(remotePeerId) ||
+    this.#connectedPeers.has(remotePeerId)
+  ) {
+    return false;
   }
-  
-  // Eagerly reserve the peer ID in the connecting collection to prevent 
-  // duplicate concurrent signaling from other trackers.
-  // A timeout is applied to release the lock if signaling fails or stalls.
+
   const timeoutId = setTimeout(() => {
-    const peer = this.connectingPeers.get(remotePeerId);
+    const peer = this.#connectingPeers.get(remotePeerId);
     if (peer?.status === "signaling") {
-      this.connectingPeers.delete(remotePeerId);
+      this.#connectingPeers.delete(remotePeerId);
     }
   }, timeout);
 
-  this.connectingPeers.set(remotePeerId, { status: "signaling", timeoutId }); 
+  this.#connectingPeers.set(remotePeerId, {
+    status: "signaling",
+    timeoutId,
+  });
   return true;
-}
+};
 ```
-*Note: If the WebRTC connection fails or the upper layer rejects the peer later, the upper layer must call `peer.close()` to remove it from the collections, allowing future reconnection attempts.*
+*Note: If the WebRTC signaling fails (e.g. ICE gathering timeout), the `WebTorrentClient` emits a `peerSignalingFailed` event, and the Manager automatically cleans up the `"signaling"` state to allow future reconnection attempts. If the connection fails after signaling, or the upper layer rejects the peer later, the upper layer must invoke the `close()` callback (provided in the `peerConnected` payload) to cleanly close the connection and remove it from the internal collections.*
 
 ### Peer Connection Lifecycle
-When a child `WebTorrentClient` emits a `peerSignaled` event, the Manager updates the existing reserved entry in the `connectingPeers` collection with the actual `RTCPeerConnection` and listens to the `RTCDataChannel` state changes. 
-A **15-second timeout** is applied to wait for the data channel to fully open.
-If the data channel successfully opens within the timeout, the Manager removes the peer from `connectingPeers`, stores it in `connectedPeers`, and emits a `peerConnected` event with the established channel. 
-If the connection times out, fails, or the data channel fails to open, the Manager cleans up the connection, removes it from `connectingPeers`, and emits a `peerConnectFailed` event for outside logging.
+When a child `WebTorrentClient` emits a `peerSignaled` event, the Manager transitions the peer from the `"signaling"` state to the `"connecting"` state. It updates the entry in the `#connectingPeers` map with the actual `RTCPeerConnection` and starts listening to both `RTCPeerConnection` state events (`connectionstatechange`, `iceconnectionstatechange`) and the `RTCDataChannel` state.
 
-Once connected, the Manager continues to listen to lifecycle events (`connectionstatechange`, `iceconnectionstatechange`, and data channel `close`/`error`). If the connection drops unexpectedly (e.g. the remote peer crashes), the Manager synchronously extracts the peer from its internal map, closes the connection, and emits a `peerDisconnected` event. 
+#### Terminal States
+For live video streaming, the manager treats certain transient or failing states as terminal:
+- `failed`, `closed`, and `disconnected` states on either `connectionState` or `iceConnectionState` are treated as immediate terminal failure states. Dropping the peer immediately and reconnecting via a tracker is faster than waiting for a stale/disconnected connection to potentially recover.
 
-To intentionally close a connection, the upper layer **must call `peer.close()`** (provided in the `peerConnected` payload) instead of `connection.close()`. This follows the exact same cleanup flow: it synchronously removes the peer from the internal map, closes the connection, and emits `peerDisconnected`. 
+A **15-second timeout** (`DATA_CHANNEL_TIMEOUT`) is applied to wait for the data channel to fully open.
+- If the data channel successfully opens (or is already open) within the timeout, the Manager removes the peer from `#connectingPeers`, stores it in `#connectedPeers` (promoting it to `"connected"`), and dispatches the `peerConnected` event.
+- If the connection times out, enters a terminal state, or the data channel fails/closes prematurely, the Manager cleans up, closes the connection, deletes the peer from `#connectingPeers`, and dispatches a `peerConnectFailed` event.
 
-This guarantees a strict **1-to-1 parity** between `peerConnected` and `peerDisconnected` events, establishing the Manager as the definitive Single Source of Truth for peer lifecycles. It is impossible for `peerDisconnected` to double-fire, because both the automatic listener and the manual `peer.close()` method synchronously extract and delete the peer from the internal map before firing the event.
+#### Connected Peer Lifecycle
+Once connected, the Manager continues to monitor the peer for connection drops or errors. If the connection drops unexpectedly (e.g., the remote peer crashes or enters a terminal connection state like `disconnected`), the Manager:
+1. Synchronously extracts the peer from the `#connectedPeers` map.
+2. Closes the connection and performs necessary cleanup.
+3. Dispatches a `peerDisconnected` event detailing the `reason` and whether `isError` is true.
+
+#### Intentional Disconnection
+To intentionally close a connection, the upper layer **must invoke the `close(error?: string)` callback** provided in the `peerConnected` event payload.
+- Calling `close()` without arguments results in a standard disconnection with `reason: "Closed by consumer"` and `isError: false`.
+- Calling `close(errorMessage)` results in a disconnection with `reason` set to the provided message and `isError: true`.
+
+This follows the exact same cleanup flow: it synchronously extracts and deletes the peer from the `#connectedPeers` map, closes the connection, and dispatches a `peerDisconnected` event.
+
+This guarantees a strict **1-to-1 parity** between `peerConnected` and `peerDisconnected` events, establishing the Manager as the definitive Single Source of Truth for peer lifecycles. It is impossible for `peerDisconnected` to double-fire, because both the automatic listeners and the manual `close()` callback synchronously extract and delete the peer from the internal map before dispatching the event.
 
 ### Event Aggregation
 The Manager attaches event listeners to every `WebTorrentClient`. When a client emits a `warning` or `error`, the Manager wraps it with the specific `trackerUrl` and emits it upstream. This allows the Swarm Manager to log exactly which tracker is failing without needing to manage the clients directly.

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/spec.md
@@ -7,6 +7,7 @@ A high-level manager that orchestrates multiple `WebTorrentClient` instances con
 While a `WebTorrentClient` handles signaling for exactly **one** tracker, a real-world BitTorrent/WebTorrent swarm typically involves multiple trackers for redundancy and peer discovery. The `WebTorrentManager` is responsible for fanning out to these multiple trackers while presenting a single, unified interface to the higher layers (e.g., Swarm Manager).
 
 **Key Responsibilities:**
+
 1. **WebSocket Pooling**: Utilizes the `WebTorrentSocketPool` to share `WebSocketClient` connections. If multiple `WebTorrentManager` instances (for different `infoHash`es) use the same tracker URL, they will safely share the same underlying WebSocket.
 2. **Aggregating Trackers**: Spins up and manages a `WebTorrentClient` for each configured tracker URL.
 3. **Peer Uniqueness & Deduplication**: Ensures that the same remote peer is not connected multiple times, even if discovered across multiple trackers simultaneously.
@@ -20,9 +21,9 @@ While a `WebTorrentClient` handles signaling for exactly **one** tracker, a real
 
 ```typescript
 interface WebTorrentManagerConfig {
-  infoHash: string;             // 20-byte hex string representing the torrent
-  peerId: string;               // 20-byte hex string representing this client
-  trackerUrls: string[];        // Array of WebSocket tracker URLs to connect to
+  infoHash: string; // 20-byte hex string representing the torrent
+  peerId: string; // 20-byte hex string representing this client
+  trackerUrls: string[]; // Array of WebSocket tracker URLs to connect to
   rtcConfig?: RTCConfiguration; // WebRTC STUN/TURN configuration
   channelConfig?: RTCDataChannelInit; // Data Channel configuration
   socketPool: WebTorrentSocketPool; // Shared socket pool
@@ -40,7 +41,7 @@ interface WebTorrentManagerConfig {
 
 The Manager aggregates events from all child clients and forwards/handles them.
 
-- `peerConnected` (payload: `{ peerId: string, connection: RTCPeerConnection, channel: RTCDataChannel, trackerUrl: string, close: (error?: string) => void }`): Fired when a peer finishes WebRTC signaling on *any* tracker and its Data Channel is successfully opened.
+- `peerConnected` (payload: `{ peerId: string, connection: RTCPeerConnection, channel: RTCDataChannel, trackerUrl: string, close: (error?: string) => void }`): Fired when a peer finishes WebRTC signaling on _any_ tracker and its Data Channel is successfully opened.
 - `peerDisconnected` (payload: `{ peerId: string, reason: string, isError: boolean }`): Fired when a fully connected peer is closed, either due to an unexpected disconnect (e.g., network loss), manager destruction, or a manual call to the peer's `close` callback.
 - `peerConnectFailed` (payload: `{ peerId: string, trackerUrl: string, error: string }`): Fired if a signaled peer fails to connect or its data channel fails to open.
 - `warning` (payload: `{ trackerUrl: string, warning: string }`): Aggregated tracker warnings.
@@ -51,11 +52,13 @@ The Manager aggregates events from all child clients and forwards/handles them.
 ## 2. Architecture & Lifecycle
 
 ### Socket Pool Integration
+
 For each URL in `trackerUrls`, the Manager calls `socketPool.acquire(url)`. This returns an object containing the `client` (a `WebSocketClient`) and a `release()` closure.
 The Manager then constructs a `WebTorrentClient`, passing the acquired `WebSocketClient` into its configuration.
 When the Manager is destroyed, it calls `client.destroy()` on the `WebTorrentClient`s, and then invokes the `release()` closure for each socket to return it to the pool.
 
 ### Peer Deduplication across Trackers
+
 Because a user might be active on `wss://tracker1.com` and `wss://tracker2.com`, both trackers might send us the same remote `peer_id`.
 To adhere to the Single Source of Truth principle, the `WebTorrentManager` avoids managing a separate set of known peers. Instead, it checks its existing collections of connected and connecting peers.
 It passes a bound `#claimPeer` callback into every `WebTorrentClient` it creates:
@@ -85,27 +88,36 @@ It passes a bound `#claimPeer` callback into every `WebTorrentClient` it creates
   return true;
 };
 ```
-*Note: If the WebRTC signaling fails (e.g. ICE gathering timeout), the `WebTorrentClient` emits a `peerSignalingFailed` event, and the Manager automatically cleans up the `"signaling"` state to allow future reconnection attempts. If the connection fails after signaling, or the upper layer rejects the peer later, the upper layer must invoke the `close()` callback (provided in the `peerConnected` payload) to cleanly close the connection and remove it from the internal collections.*
+
+_Note: If the WebRTC signaling fails (e.g. ICE gathering timeout), the `WebTorrentClient` emits a `peerSignalingFailed` event, and the Manager automatically cleans up the `"signaling"` state to allow future reconnection attempts. If the connection fails after signaling, or the upper layer rejects the peer later, the upper layer must invoke the `close()` callback (provided in the `peerConnected` payload) to cleanly close the connection and remove it from the internal collections._
 
 ### Peer Connection Lifecycle
+
 When a child `WebTorrentClient` emits a `peerSignaled` event, the Manager transitions the peer from the `"signaling"` state to the `"connecting"` state. It updates the entry in the `#connectingPeers` map with the actual `RTCPeerConnection` and starts listening to both `RTCPeerConnection` state events (`connectionstatechange`, `iceconnectionstatechange`) and the `RTCDataChannel` state.
 
 #### Terminal States
+
 For live video streaming, the manager treats certain transient or failing states as terminal:
+
 - `failed`, `closed`, and `disconnected` states on either `connectionState` or `iceConnectionState` are treated as immediate terminal failure states. Dropping the peer immediately and reconnecting via a tracker is faster than waiting for a stale/disconnected connection to potentially recover.
 
 A **15-second timeout** (`DATA_CHANNEL_TIMEOUT`) is applied to wait for the data channel to fully open.
+
 - If the data channel successfully opens (or is already open) within the timeout, the Manager removes the peer from `#connectingPeers`, stores it in `#connectedPeers` (promoting it to `"connected"`), and dispatches the `peerConnected` event.
 - If the connection times out, enters a terminal state, or the data channel fails/closes prematurely, the Manager cleans up, closes the connection, deletes the peer from `#connectingPeers`, and dispatches a `peerConnectFailed` event.
 
 #### Connected Peer Lifecycle
+
 Once connected, the Manager continues to monitor the peer for connection drops or errors. If the connection drops unexpectedly (e.g., the remote peer crashes or enters a terminal connection state like `disconnected`), the Manager:
+
 1. Synchronously extracts the peer from the `#connectedPeers` map.
 2. Closes the connection and performs necessary cleanup.
 3. Dispatches a `peerDisconnected` event detailing the `reason` and whether `isError` is true.
 
 #### Intentional Disconnection
+
 To intentionally close a connection, the upper layer **must invoke the `close(error?: string)` callback** provided in the `peerConnected` event payload.
+
 - Calling `close()` without arguments results in a standard disconnection with `reason: "Closed by consumer"` and `isError: false`.
 - Calling `close(errorMessage)` results in a disconnection with `reason` set to the provided message and `isError: true`.
 
@@ -114,4 +126,5 @@ This follows the exact same cleanup flow: it synchronously extracts and deletes 
 This guarantees a strict **1-to-1 parity** between `peerConnected` and `peerDisconnected` events, establishing the Manager as the definitive Single Source of Truth for peer lifecycles. It is impossible for `peerDisconnected` to double-fire, because both the automatic listeners and the manual `close()` callback synchronously extract and delete the peer from the internal map before dispatching the event.
 
 ### Event Aggregation
+
 The Manager attaches event listeners to every `WebTorrentClient`. When a client emits a `warning` or `error`, the Manager wraps it with the specific `trackerUrl` and emits it upstream. This allows the Swarm Manager to log exactly which tracker is failing without needing to manage the clients directly.

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-socket-pool/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-socket-pool/spec.md
@@ -16,16 +16,16 @@ The pool implements an event target system (`EventTarget`) that emits global eve
 
 ## API Reference
 
-### `acquire(url: string)`
+### `acquire(url: string): { client: WebSocketClient; release: () => void }`
 Acquires a `WebSocketClient` for the given URL.
 - Returns an object containing:
   - `client`: The `WebSocketClient` instance.
   - `release`: A callback function to release the reference to the client. This callback is idempotent and gracefully handles multiple calls by only releasing once.
 
-### `addEventListener(eventName, listener)` / `removeEventListener(eventName, listener)`
+### `addEventListener<K extends keyof WebTorrentSocketPoolEventMap>(eventName: K, listener: WebTorrentSocketPoolEventMap[K]): void` / `removeEventListener<K extends keyof WebTorrentSocketPoolEventMap>(eventName: K, listener: WebTorrentSocketPoolEventMap[K]): void`
 Allows attaching and detaching event listeners to the pool.
 - Supported events:
-  - `error: (error: Event, url: string) => void` - Listen for underlying socket errors.
+  - `error`: `(error: Event, url: string) => void` - Listen for underlying socket errors.
 
-### `destroy()`
+### `destroy(): void`
 Forcefully disposes of all pooled `WebSocketClient` connections and cleans up all existing event listeners. It safely catches and logs any errors thrown during individual socket disposal.

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-socket-pool/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-socket-pool/spec.md
@@ -1,9 +1,11 @@
 # WebTorrent Socket Pool
 
 ## Overview
+
 `WebTorrentSocketPool` manages the lifecycle and reuse of WebSocket connections (`WebSocketClient`) for WebTorrent trackers. It ensures that a single connection per unique URL is shared across multiple clients requiring access, avoiding redundant socket connections.
 
 ## Reference Counting & Lifecycle
+
 - When a `WebSocketClient` for a specific URL is requested via `acquire(url)`, the pool checks if an active connection exists.
 - If one exists, the pool increments its reference count and returns the client along with a `release` function.
 - If one doesn't exist, the pool creates a new `WebSocketClient`, establishes a connection, initializes its reference count to `1`, and stores it.
@@ -11,21 +13,28 @@
 - If the reference count drops to `0`, the socket is fully disconnected (`dispose` is called) and removed from the pool.
 
 ## Event Handling
+
 The pool implements an event target system (`EventTarget`) that emits global events for the underlying sockets it manages.
+
 - **`error`**: Dispatched when any managed `WebSocketClient` encounters an error. Provides the underlying `Event` object as well as the tracker `url` where the error originated.
 
 ## API Reference
 
 ### `acquire(url: string): { client: WebSocketClient; release: () => void }`
+
 Acquires a `WebSocketClient` for the given URL.
+
 - Returns an object containing:
   - `client`: The `WebSocketClient` instance.
   - `release`: A callback function to release the reference to the client. This callback is idempotent and gracefully handles multiple calls by only releasing once.
 
 ### `addEventListener<K extends keyof WebTorrentSocketPoolEventMap>(eventName: K, listener: WebTorrentSocketPoolEventMap[K]): void` / `removeEventListener<K extends keyof WebTorrentSocketPoolEventMap>(eventName: K, listener: WebTorrentSocketPoolEventMap[K]): void`
+
 Allows attaching and detaching event listeners to the pool.
+
 - Supported events:
   - `error`: `(error: Event, url: string) => void` - Listen for underlying socket errors.
 
 ### `destroy(): void`
+
 Forcefully disposes of all pooled `WebSocketClient` connections and cleans up all existing event listeners. It safely catches and logs any errors thrown during individual socket disposal.

--- a/packages/p2p-media-loader-core/test/hash.test.ts
+++ b/packages/p2p-media-loader-core/test/hash.test.ts
@@ -6,25 +6,41 @@ describe("hash.ts", () => {
   describe("sha1", () => {
     it("should correctly hash a simple string", () => {
       const testStr = "hello world123!@#";
-      const nodeHash = crypto.createHash("sha1").update(testStr).digest().toString("latin1");
+      const nodeHash = crypto
+        .createHash("sha1")
+        .update(testStr)
+        .digest()
+        .toString("latin1");
       expect(sha1(testStr)).toBe(nodeHash);
     });
 
     it("should correctly hash an empty string", () => {
       const testStr = "";
-      const nodeHash = crypto.createHash("sha1").update(testStr).digest().toString("latin1");
+      const nodeHash = crypto
+        .createHash("sha1")
+        .update(testStr)
+        .digest()
+        .toString("latin1");
       expect(sha1(testStr)).toBe(nodeHash);
     });
 
     it("should correctly hash a long string", () => {
       const testStr = "a".repeat(1000);
-      const nodeHash = crypto.createHash("sha1").update(testStr).digest().toString("latin1");
+      const nodeHash = crypto
+        .createHash("sha1")
+        .update(testStr)
+        .digest()
+        .toString("latin1");
       expect(sha1(testStr)).toBe(nodeHash);
     });
 
     it("should correctly hash strings with non-ASCII characters", () => {
       const testStr = "привіт світ 🔥";
-      const nodeHash = crypto.createHash("sha1").update(testStr).digest().toString("latin1");
+      const nodeHash = crypto
+        .createHash("sha1")
+        .update(testStr)
+        .digest()
+        .toString("latin1");
       expect(sha1(testStr)).toBe(nodeHash);
     });
 

--- a/packages/p2p-media-loader-core/tsconfig.json
+++ b/packages/p2p-media-loader-core/tsconfig.json
@@ -6,5 +6,8 @@
     "tsBuildInfoFile": "./build/.tsbuildinfo"
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "./tsconfig.test.json" }, { "path": "./tsconfig.node.json" }]
+  "references": [
+    { "path": "./tsconfig.test.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
 }

--- a/packages/p2p-media-loader-core/tsconfig.node.json
+++ b/packages/p2p-media-loader-core/tsconfig.node.json
@@ -7,5 +7,9 @@
     "emitDeclarationOnly": true
   },
   "types": ["node"],
-  "include": ["vite.config.ts", "eslint.config.ts", "../../eslint.common.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "eslint.config.ts",
+    "../../eslint.common.config.ts"
+  ]
 }

--- a/packages/p2p-media-loader-core/tsconfig.test.json
+++ b/packages/p2p-media-loader-core/tsconfig.test.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "Bundler"
   },
   "types": ["vitest", "node"],
-  "include": ["test/**/*"],
+  "include": ["test/**/*"]
 }

--- a/packages/p2p-media-loader-demo/package.json
+++ b/packages/p2p-media-loader-demo/package.json
@@ -43,7 +43,7 @@
     "copy-css": "cpy \"src/**/*.css\" \"./lib/\" --parents",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0 --flag unstable_native_nodejs_ts_config",
     "type-check": "npx tsc --noEmit",
-    "clean-build": "rimraf lib dist build p2p-media-loader-demo-*.tgz"
+    "clean:build": "rimraf lib dist build p2p-media-loader-demo-*.tgz"
   },
   "dependencies": {
     "@vidstack/react": "^1.12.13",

--- a/packages/p2p-media-loader-demo/tsconfig.json
+++ b/packages/p2p-media-loader-demo/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
     "outDir": "lib",
     "rootDir": "src",
     "tsBuildInfoFile": "./build/.tsbuildinfo",

--- a/packages/p2p-media-loader-hlsjs/package.json
+++ b/packages/p2p-media-loader-hlsjs/package.json
@@ -40,13 +40,15 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "rimraf lib build && pnpm build:es && pnpm build:esm && pnpm build:esm-min",
+    "build": "rimraf lib build && pnpm build:es && pnpm build:esm && pnpm build:esm-min && pnpm build:iife && pnpm build:iife-min",
     "build:esm": "vite build --mode esm",
     "build:esm-min": "vite build --mode esm-min",
+    "build:iife": "vite build --mode iife",
+    "build:iife-min": "vite build --mode iife-min",
     "build:es": "tsc",
     "prettier": "prettier --write .",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0 --flag unstable_native_nodejs_ts_config",
-    "clean-build": "rimraf lib dist build p2p-media-loader-hlsjs-*.tgz",
+    "clean:build": "rimraf lib dist build p2p-media-loader-hlsjs-*.tgz",
     "type-check": "npx tsc --noEmit"
   },
   "dependencies": {

--- a/packages/p2p-media-loader-hlsjs/src/fragment-loader.ts
+++ b/packages/p2p-media-loader-hlsjs/src/fragment-loader.ts
@@ -83,16 +83,16 @@ export class FragmentLoaderBase implements Loader<FragmentLoaderContext> {
       stats.total = loadedBytes;
       stats.loaded = loadedBytes;
 
+      // hls.js transfers the ArrayBuffer to a Web Worker for transmuxing, which
+      // detaches the ArrayBuffer and sets its byteLength to 0. We clone it here
+      // to keep our cached ArrayBuffer intact for seeding to other peers.
+      const engineData = this.#response.data.slice(0);
+
       if (callbacks.onProgress) {
-        callbacks.onProgress(
-          this.stats,
-          context,
-          this.#response.data,
-          undefined,
-        );
+        callbacks.onProgress(this.stats, context, engineData, undefined);
       }
       callbacks.onSuccess(
-        { data: this.#response.data, url: context.url },
+        { data: engineData, url: context.url },
         this.stats,
         context,
         undefined,
@@ -159,9 +159,10 @@ function getLoadingStat(
   loadedBytes: number,
   loadingEndTime: number,
 ) {
-  const timeForLoading = (loadedBytes * 8000) / targetBitrate;
-  const first = loadingEndTime - timeForLoading;
-  const start = first - DEFAULT_DOWNLOAD_LATENCY;
+  const timeForLoading =
+    targetBitrate > 0 ? (loadedBytes * 8000) / targetBitrate : 0;
+  const first = Math.max(0, loadingEndTime - timeForLoading);
+  const start = Math.max(0, first - DEFAULT_DOWNLOAD_LATENCY);
 
   return { start, first, end: loadingEndTime };
 }

--- a/packages/p2p-media-loader-hlsjs/src/index.ts
+++ b/packages/p2p-media-loader-hlsjs/src/index.ts
@@ -1,4 +1,5 @@
 export { HlsJsP2PEngine } from "./engine.js";
+export { Core } from "p2p-media-loader-core";
 
 export type {
   DynamicHlsJsP2PEngineConfig,

--- a/packages/p2p-media-loader-hlsjs/tsconfig.node.json
+++ b/packages/p2p-media-loader-hlsjs/tsconfig.node.json
@@ -7,5 +7,9 @@
     "emitDeclarationOnly": true
   },
   "types": ["node"],
-  "include": ["vite.config.ts", "eslint.config.ts", "../../eslint.common.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "eslint.config.ts",
+    "../../eslint.common.config.ts"
+  ]
 }

--- a/packages/p2p-media-loader-hlsjs/vite.config.ts
+++ b/packages/p2p-media-loader-hlsjs/vite.config.ts
@@ -21,12 +21,35 @@ const getESMConfig = ({ minify }: { minify: boolean }): UserConfig => {
   };
 };
 
+const getIIFEConfig = ({ minify }: { minify: boolean }): UserConfig => {
+  return {
+    build: {
+      emptyOutDir: false,
+      minify,
+      sourcemap: true,
+      target: "es2015",
+      lib: {
+        name: "p2pml.hlsjs",
+        fileName: (format) =>
+          `p2p-media-loader-hlsjs.${format}${minify ? ".min" : ""}.js`,
+        formats: ["iife"],
+        entry: "src/index.ts",
+      },
+    },
+  };
+};
+
 export default defineConfig(({ mode }) => {
   switch (mode) {
     case "esm":
       return getESMConfig({ minify: false });
 
     case "esm-min":
+      return getESMConfig({ minify: true });
+    case "iife":
+      return getIIFEConfig({ minify: false });
+    case "iife-min":
+      return getIIFEConfig({ minify: true });
     default:
       return getESMConfig({ minify: true });
   }

--- a/packages/p2p-media-loader-shaka/package.json
+++ b/packages/p2p-media-loader-shaka/package.json
@@ -41,13 +41,15 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "rimraf lib build && pnpm build:es && pnpm build:esm && pnpm build:esm-min",
+    "build": "rimraf lib build && pnpm build:es && pnpm build:esm && pnpm build:esm-min && pnpm build:iife && pnpm build:iife-min",
     "build:esm": "vite build --mode esm",
     "build:esm-min": "vite build --mode esm-min",
+    "build:iife": "vite build --mode iife",
+    "build:iife-min": "vite build --mode iife-min",
     "build:es": "tsc",
     "prettier": "prettier --write .",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0 --flag unstable_native_nodejs_ts_config",
-    "clean-build": "rimraf lib dist build p2p-media-loader-shaka-*.tgz",
+    "clean:build": "rimraf lib dist build p2p-media-loader-shaka-*.tgz",
     "type-check": "npx tsc --noEmit"
   },
   "dependencies": {

--- a/packages/p2p-media-loader-shaka/src/index.ts
+++ b/packages/p2p-media-loader-shaka/src/index.ts
@@ -1,4 +1,6 @@
 export { ShakaP2PEngine } from "./engine.js";
+export { Core } from "p2p-media-loader-core";
+
 export type {
   DynamicShakaP2PEngineConfig,
   ShakaP2PEngineConfig,

--- a/packages/p2p-media-loader-shaka/src/loading-handler.ts
+++ b/packages/p2p-media-loader-shaka/src/loading-handler.ts
@@ -117,7 +117,7 @@ function getLoadingDurationBasedOnBandwidth(
   bytesLoaded: number,
 ) {
   const bits = bytesLoaded * 8;
-  return Math.round(bits / bandwidth) * 1000;
+  return bandwidth > 0 ? Math.round(bits / bandwidth) * 1000 : 0;
 }
 
 function getSegmentRequest(): {

--- a/packages/p2p-media-loader-shaka/src/manifest-parser-decorator.ts
+++ b/packages/p2p-media-loader-shaka/src/manifest-parser-decorator.ts
@@ -12,15 +12,7 @@ import {
   generateStreamShortId,
 } from "p2p-media-loader-core";
 
-const AUDIO_CODECS = [
-  "mp4a",
-  "ac-3",
-  "ec-3",
-  "ec+3",
-  "opus",
-  "vorb",
-  "flac",
-];
+const AUDIO_CODECS = ["mp4a", "ac-3", "ec-3", "ec+3", "opus", "vorb", "flac"];
 
 export class ManifestParserDecorator implements shaka.extern.ManifestParser {
   private readonly debug = debug("p2pml-shaka:manifest-parser");
@@ -269,7 +261,7 @@ export class ManifestParserDecorator implements shaka.extern.ManifestParser {
     }
 
     // For version 4.2; Retrieving mediaSequence map for each HLS playlist
-    const manifestVariantsMap = maps.find((map) => {
+    const manifestVariantsMap = maps.find((map: Map<unknown, unknown>) => {
       const item = map.values().next().value;
 
       return (
@@ -288,7 +280,7 @@ export class ManifestParserDecorator implements shaka.extern.ManifestParser {
 
       const mediaSequenceTimeMap = getMapPropertiesFromObject(
         variant as Record<string, unknown>,
-      ).find((map) => {
+      ).find((map: Map<unknown, unknown>) => {
         const [key, value] = map.entries().next().value ?? [];
         return typeof key === "number" && typeof value === "number";
       });
@@ -337,7 +329,10 @@ function getReferencesArray(
 }
 
 function getMapPropertiesFromObject(object: Record<string, unknown>) {
-  return Object.values(object).filter(
-    (property): property is Map<unknown, unknown> => property instanceof Map,
-  );
+  // TODO: rewrite to Object.values once the project is migrated to ES2017+
+  return Object.keys(object)
+    .map((key) => object[key])
+    .filter(
+      (property): property is Map<unknown, unknown> => property instanceof Map,
+    );
 }

--- a/packages/p2p-media-loader-shaka/tsconfig.node.json
+++ b/packages/p2p-media-loader-shaka/tsconfig.node.json
@@ -7,5 +7,9 @@
     "emitDeclarationOnly": true
   },
   "types": ["node"],
-  "include": ["vite.config.ts", "eslint.config.ts", "../../eslint.common.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "eslint.config.ts",
+    "../../eslint.common.config.ts"
+  ]
 }

--- a/packages/p2p-media-loader-shaka/vite.config.ts
+++ b/packages/p2p-media-loader-shaka/vite.config.ts
@@ -21,12 +21,35 @@ const getESMConfig = ({ minify }: { minify: boolean }): UserConfig => {
   };
 };
 
+const getIIFEConfig = ({ minify }: { minify: boolean }): UserConfig => {
+  return {
+    build: {
+      emptyOutDir: false,
+      minify,
+      sourcemap: true,
+      target: "es2015",
+      lib: {
+        name: "p2pml.shaka",
+        fileName: (format) =>
+          `p2p-media-loader-shaka.${format}${minify ? ".min" : ""}.js`,
+        formats: ["iife"],
+        entry: "src/index.ts",
+      },
+    },
+  };
+};
+
 export default defineConfig(({ mode }) => {
   switch (mode) {
     case "esm":
       return getESMConfig({ minify: false });
 
     case "esm-min":
+      return getESMConfig({ minify: true });
+    case "iife":
+      return getIIFEConfig({ minify: false });
+    case "iife-min":
+      return getIIFEConfig({ minify: true });
     default:
       return getESMConfig({ minify: true });
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2015",
     "useDefineForClassFields": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2015", "DOM"],
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Description
- Added IIFE build format support to hlsjs and shaka engines
- Exported Core from p2p-media-loader-hlsjs and p2p-media-loader-shaka
- Downgraded TypeScript target to ES2015
- Fixed zero division bugs in loading duration calculations
- Added IIFE demos
- Updated documentation