### PR TITLE
refactor(webtorrent): encapsulate WebRTC connection and state tracking in WebTorrentClient

### DIFF
--- a/packages/p2p-media-loader-core/src/utils/event-target.ts
+++ b/packages/p2p-media-loader-core/src/utils/event-target.ts
@@ -14,7 +14,11 @@ export class EventTarget<
     const listeners = this.events.get(eventName);
     if (!listeners) return;
     for (const listener of listeners) {
-      listener(...args);
+      try {
+        listener(...args);
+      } catch {
+        // Swallow user-land errors to protect internal invariants
+      }
     }
   }
 
@@ -29,7 +33,11 @@ export class EventTarget<
 
     return (...args: Parameters<EventTypesMap[K]>) => {
       for (const listener of definedListeners) {
-        listener(...args);
+        try {
+          listener(...args);
+        } catch {
+          // Swallow user-land errors to protect internal invariants
+        }
       }
     };
   }

--- a/packages/p2p-media-loader-core/src/webtorrent/utils.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/utils.ts
@@ -18,3 +18,14 @@ export function getRTCErrorMessage(
 ): string {
   return getRTCError(event, fallbackMessage).message;
 }
+
+export function isTerminalConnectionState(
+  state: RTCIceConnectionState | RTCPeerConnectionState,
+): boolean {
+  // "disconnected" is technically a transient ICE state that can recover,
+  // but for live video streaming we treat it as terminal: dropping the peer
+  // immediately and reconnecting via the tracker is faster than waiting for
+  // a stale connection to potentially recover.
+
+  return state === "failed" || state === "closed" || state === "disconnected";
+}

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
@@ -1,23 +1,22 @@
 import { EventTarget } from "../../utils/event-target.js";
-import {
-  WebSocketClient,
-  WebSocketClientState,
-} from "../websocket-client/index.js";
+import { getPromiseWithResolvers } from "../../utils/utils.js";
+import { isTerminalConnectionState } from "../utils.js";
+import { WebSocketClient } from "../websocket-client/index.js";
 
 export type WebTorrentClientEventMap = {
-  peerSignaled: (event: {
+  peerConnected: (event: {
     peerId: string;
     connection: RTCPeerConnection;
-    channel?: RTCDataChannel;
+    channel: RTCDataChannel;
   }) => void;
-  peerSignalingFailed: (event: { peerId: string; error: string }) => void;
+  peerConnectFailed: (event: { peerId: string; error: string }) => void;
   warning: (warning: string) => void;
   error: (error: string) => void;
 };
 
-export type WebTorrentClientState = WebSocketClientState;
-
 const WEBTORRENT_DEFAULT_OFFER_TIMEOUT = 50000;
+const WEBTORRENT_DEFAULT_CONNECTION_TIMEOUT = 15000;
+const WEBTORRENT_DEFAULT_OFFERS_COUNT = 5;
 
 export interface WebTorrentClientConfig {
   wsClient: WebSocketClient;
@@ -27,7 +26,8 @@ export interface WebTorrentClientConfig {
   channelConfig?: RTCDataChannelInit;
   offerTimeout?: number;
   offersCount?: number;
-  claimPeer?: (peerId: string, timeout: number) => boolean;
+  connectionTimeout?: number;
+  claimPeer?: (peerId: string) => boolean;
   shouldGenerateOffers?: () => boolean;
 }
 
@@ -85,10 +85,21 @@ export class WebTorrentClient {
   readonly #negotiatingConnections = new Set<RTCPeerConnection>();
   readonly #destroyAbortController = new AbortController();
 
-  #announceIntervalId: ReturnType<typeof setInterval> | null = null;
+  #announceTimeoutId: ReturnType<typeof setTimeout> | null = null;
   #announceIntervalSeconds: number | null = null;
+  #announceRunId = 0;
   #trackerId: string | null = null;
-  #destroyed = false;
+  #started = false;
+
+  #isDestroyed(): boolean {
+    return this.#destroyAbortController.signal.aborted;
+  }
+
+  #throwIfDestroyed(): void {
+    if (this.#destroyAbortController.signal.aborted) {
+      throw new Error("Client destroyed");
+    }
+  }
 
   constructor(config: WebTorrentClientConfig) {
     this.#config = {
@@ -97,16 +108,14 @@ export class WebTorrentClient {
       rtcConfig: config.rtcConfig,
       channelConfig: config.channelConfig,
       offerTimeout: config.offerTimeout ?? WEBTORRENT_DEFAULT_OFFER_TIMEOUT,
-      offersCount: config.offersCount ?? 5,
+      offersCount: config.offersCount ?? WEBTORRENT_DEFAULT_OFFERS_COUNT,
+      connectionTimeout:
+        config.connectionTimeout ?? WEBTORRENT_DEFAULT_CONNECTION_TIMEOUT,
       claimPeer: config.claimPeer ?? (() => true),
       shouldGenerateOffers: config.shouldGenerateOffers ?? (() => true),
     };
 
     this.#wsClient = config.wsClient;
-
-    this.#wsClient.addEventListener("connected", this.#onWsConnected);
-    this.#wsClient.addEventListener("disconnected", this.#onWsDisconnected);
-    this.#wsClient.addEventListener("message", this.#onWsMessage);
   }
 
   public addEventListener<K extends keyof WebTorrentClientEventMap>(
@@ -124,7 +133,12 @@ export class WebTorrentClient {
   }
 
   public start(): void {
-    if (this.#destroyed) return;
+    if (this.#isDestroyed() || this.#started) return;
+    this.#started = true;
+
+    this.#wsClient.addEventListener("connected", this.#onWsConnected);
+    this.#wsClient.addEventListener("disconnected", this.#onWsDisconnected);
+    this.#wsClient.addEventListener("message", this.#onWsMessage);
 
     if (this.#wsClient.state === "connected") {
       this.#onWsConnected();
@@ -132,19 +146,23 @@ export class WebTorrentClient {
   }
 
   public destroy(): void {
-    if (this.#destroyed) return;
-    this.#destroyed = true;
-    this.#clearAnnounceInterval();
+    if (this.#isDestroyed()) return;
+    this.#destroyAbortController.abort();
+    this.#clearAnnounceTimeout();
 
     this.#sendStopped();
 
     this.#cleanupPendingOffers();
     this.#cleanupNegotiatingConnections();
-    this.#destroyAbortController.abort();
 
-    this.#wsClient.removeEventListener("connected", this.#onWsConnected);
-    this.#wsClient.removeEventListener("disconnected", this.#onWsDisconnected);
-    this.#wsClient.removeEventListener("message", this.#onWsMessage);
+    if (this.#started) {
+      this.#wsClient.removeEventListener("connected", this.#onWsConnected);
+      this.#wsClient.removeEventListener(
+        "disconnected",
+        this.#onWsDisconnected,
+      );
+      this.#wsClient.removeEventListener("message", this.#onWsMessage);
+    }
 
     this.#eventTarget.clear();
   }
@@ -155,6 +173,8 @@ export class WebTorrentClient {
 
     // Send the initial announce event
     this.#announce("started").catch((err: unknown) => {
+      if (this.#isDestroyed()) return;
+
       this.#eventTarget.dispatchEvent(
         "error",
         `Initial announce failed: ${String(err)}`,
@@ -163,12 +183,12 @@ export class WebTorrentClient {
   };
 
   #onWsDisconnected = (): void => {
-    this.#clearAnnounceInterval();
+    this.#clearAnnounceTimeout();
     this.#announceIntervalSeconds = null;
   };
 
   #onWsMessage = (data: ArrayBuffer | string): void => {
-    if (this.#destroyed) return;
+    if (this.#isDestroyed()) return;
 
     let msg: unknown;
 
@@ -189,11 +209,7 @@ export class WebTorrentClient {
 
     const warningMessage = dataObject["warning message"];
     if (typeof warningMessage === "string") {
-      try {
-        this.#eventTarget.dispatchEvent("warning", warningMessage);
-      } catch {
-        // Ignore user-land errors
-      }
+      this.#eventTarget.dispatchEvent("warning", warningMessage);
     }
 
     const failureReason = dataObject["failure reason"];
@@ -239,6 +255,7 @@ export class WebTorrentClient {
         peerId,
         offerId,
       }).catch((err: unknown) => {
+        if (this.#isDestroyed()) return;
         this.#eventTarget.dispatchEvent(
           "error",
           `Failed to handle offer: ${String(err)}`,
@@ -250,6 +267,7 @@ export class WebTorrentClient {
         peerId,
         offerId,
       }).catch((err: unknown) => {
+        if (this.#isDestroyed()) return;
         this.#eventTarget.dispatchEvent(
           "error",
           `Failed to handle answer: ${String(err)}`,
@@ -259,27 +277,46 @@ export class WebTorrentClient {
   };
 
   #scheduleAnnounce(intervalSeconds: number): void {
-    this.#clearAnnounceInterval();
+    this.#clearAnnounceTimeout();
     this.#announceIntervalSeconds = intervalSeconds;
-    this.#announceIntervalId = setInterval(() => {
-      this.#announce().catch((err: unknown) => {
+
+    const runId = ++this.#announceRunId;
+
+    const run = async () => {
+      try {
+        await this.#announce();
+      } catch (err: unknown) {
+        if (this.#isDestroyed()) return;
         this.#eventTarget.dispatchEvent(
           "error",
           `Announce failed: ${String(err)}`,
         );
-      });
-    }, intervalSeconds * 1000);
+      }
+
+      if (
+        !this.#isDestroyed() &&
+        this.#announceIntervalSeconds !== null &&
+        this.#announceRunId === runId
+      ) {
+        this.#announceTimeoutId = setTimeout(
+          run,
+          this.#announceIntervalSeconds * 1000,
+        );
+      }
+    };
+
+    this.#announceTimeoutId = setTimeout(run, intervalSeconds * 1000);
   }
 
-  #clearAnnounceInterval(): void {
-    if (this.#announceIntervalId !== null) {
-      clearInterval(this.#announceIntervalId);
-      this.#announceIntervalId = null;
+  #clearAnnounceTimeout(): void {
+    if (this.#announceTimeoutId !== null) {
+      clearTimeout(this.#announceTimeoutId);
+      this.#announceTimeoutId = null;
     }
   }
 
   async #announce(event?: "started"): Promise<void> {
-    if (this.#wsClient.state !== "connected") return;
+    if (this.#isDestroyed() || this.#wsClient.state !== "connected") return;
 
     const shouldGenerateOffers = this.#config.shouldGenerateOffers();
     const offersCount = shouldGenerateOffers ? this.#config.offersCount : 0;
@@ -295,7 +332,14 @@ export class WebTorrentClient {
       ),
     );
 
-    if (this.#checkDestroyed()) return;
+    if (this.#isDestroyed()) {
+      for (const result of results) {
+        if (result) {
+          this.#cleanupPendingOffer(result.offer_id);
+        }
+      }
+      return;
+    }
 
     const offers: { offer: { type: string; sdp: string }; offer_id: string }[] =
       [];
@@ -314,7 +358,7 @@ export class WebTorrentClient {
 
     try {
       this.#wsClient.send(JSON.stringify(payload));
-    } catch (err) {
+    } catch (err: unknown) {
       for (const offer of offers) {
         this.#cleanupPendingOffer(offer.offer_id);
       }
@@ -329,6 +373,8 @@ export class WebTorrentClient {
       }
     | undefined
   > {
+    if (this.#isDestroyed()) return undefined;
+
     let pc: RTCPeerConnection | undefined;
     try {
       pc = new RTCPeerConnection(this.#config.rtcConfig);
@@ -340,16 +386,16 @@ export class WebTorrentClient {
       );
 
       const offer = await pc.createOffer();
-      if (this.#checkDestroyed()) return undefined;
+      this.#throwIfDestroyed();
 
       await pc.setLocalDescription(offer);
-      if (this.#checkDestroyed()) return undefined;
+      this.#throwIfDestroyed();
 
       await this.#waitForIceGathering(pc);
-      if (this.#checkDestroyed()) return undefined;
+      this.#throwIfDestroyed();
 
       const sdp = pc.localDescription;
-      if (!sdp) {
+      if (!sdp?.sdp) {
         pc.close();
         return undefined;
       }
@@ -370,10 +416,12 @@ export class WebTorrentClient {
       };
     } catch (err: unknown) {
       pc?.close();
-      this.#eventTarget.dispatchEvent(
-        "error",
-        `Failed to create offer: ${String(err)}`,
-      );
+      if (!this.#isDestroyed()) {
+        this.#eventTarget.dispatchEvent(
+          "warning",
+          `Failed to create offer: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       return undefined;
     } finally {
       if (pc) {
@@ -433,25 +481,28 @@ export class WebTorrentClient {
     peerId: remotePeerId,
     offerId: remoteOfferId,
   }: IncomingOffer): Promise<void> {
-    if (!this.#config.claimPeer(remotePeerId, this.#config.offerTimeout)) {
+    if (this.#isDestroyed()) return;
+
+    if (!this.#config.claimPeer(remotePeerId)) {
       return; // Reject offer silently
     }
 
-    const pc = new RTCPeerConnection(this.#config.rtcConfig);
-    this.#negotiatingConnections.add(pc);
-
+    let pc: RTCPeerConnection | undefined;
     try {
+      pc = new RTCPeerConnection(this.#config.rtcConfig);
+      this.#negotiatingConnections.add(pc);
+
       await pc.setRemoteDescription(new RTCSessionDescription(offerSdp));
-      if (this.#checkDestroyed()) return;
+      this.#throwIfDestroyed();
 
       const answer = await pc.createAnswer();
-      if (this.#checkDestroyed()) return;
+      this.#throwIfDestroyed();
 
       await pc.setLocalDescription(answer);
-      if (this.#checkDestroyed()) return;
+      this.#throwIfDestroyed();
 
       await this.#waitForIceGathering(pc);
-      if (this.#checkDestroyed()) return;
+      this.#throwIfDestroyed();
 
       const sdp = pc.localDescription;
       if (!sdp) {
@@ -468,21 +519,26 @@ export class WebTorrentClient {
       };
 
       this.#wsClient.send(JSON.stringify(payload));
-    } catch (err) {
-      pc.close();
-      this.#eventTarget.dispatchEvent("peerSignalingFailed", {
-        peerId: remotePeerId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      throw err;
-    } finally {
-      this.#negotiatingConnections.delete(pc);
-    }
 
-    this.#eventTarget.dispatchEvent("peerSignaled", {
-      peerId: remotePeerId,
-      connection: pc,
-    });
+      const channel = await this.#waitForConnection(pc);
+      this.#throwIfDestroyed();
+
+      this.#eventTarget.dispatchEvent("peerConnected", {
+        peerId: remotePeerId,
+        connection: pc,
+        channel,
+      });
+    } catch (err: unknown) {
+      pc?.close();
+      if (!this.#isDestroyed()) {
+        this.#eventTarget.dispatchEvent("peerConnectFailed", {
+          peerId: remotePeerId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    } finally {
+      if (pc) this.#negotiatingConnections.delete(pc);
+    }
   }
 
   async #handleIncomingAnswer({
@@ -490,6 +546,8 @@ export class WebTorrentClient {
     peerId: remotePeerId,
     offerId: ourOfferId,
   }: IncomingAnswer): Promise<void> {
+    if (this.#isDestroyed()) return;
+
     const pending = this.#pendingOffers.get(ourOfferId);
     if (!pending) return; // Offer expired or invalid
 
@@ -497,7 +555,7 @@ export class WebTorrentClient {
     this.#pendingOffers.delete(ourOfferId);
     clearTimeout(pending.timeoutId);
 
-    if (!this.#config.claimPeer(remotePeerId, this.#config.offerTimeout)) {
+    if (!this.#config.claimPeer(remotePeerId)) {
       pending.connection.close();
       return; // Reject answer silently
     }
@@ -508,24 +566,30 @@ export class WebTorrentClient {
       await pending.connection.setRemoteDescription(
         new RTCSessionDescription(answerSdp),
       );
+      this.#throwIfDestroyed();
 
-      if (this.#checkDestroyed()) return;
+      const channel = await this.#waitForConnection(
+        pending.connection,
+        pending.channel,
+      );
+      this.#throwIfDestroyed();
+
+      this.#eventTarget.dispatchEvent("peerConnected", {
+        peerId: remotePeerId,
+        connection: pending.connection,
+        channel,
+      });
     } catch (err) {
       pending.connection.close();
-      this.#eventTarget.dispatchEvent("peerSignalingFailed", {
-        peerId: remotePeerId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      throw err;
+      if (!this.#isDestroyed()) {
+        this.#eventTarget.dispatchEvent("peerConnectFailed", {
+          peerId: remotePeerId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     } finally {
       this.#negotiatingConnections.delete(pending.connection);
     }
-
-    this.#eventTarget.dispatchEvent("peerSignaled", {
-      peerId: remotePeerId,
-      connection: pending.connection,
-      channel: pending.channel,
-    });
   }
 
   #waitForIceGathering(pc: RTCPeerConnection): Promise<void> {
@@ -545,6 +609,7 @@ export class WebTorrentClient {
         clearTimeout(timeoutId);
         pc.removeEventListener("icegatheringstatechange", onGatheringChange);
         pc.removeEventListener("icecandidate", onIceCandidate);
+        pc.removeEventListener("signalingstatechange", onSignalingChange);
         this.#destroyAbortController.signal.removeEventListener(
           "abort",
           onAbort,
@@ -567,6 +632,13 @@ export class WebTorrentClient {
         }
       };
 
+      const onSignalingChange = () => {
+        if (pc.signalingState === "closed") {
+          cleanup();
+          reject(new Error("RTCPeerConnection closed"));
+        }
+      };
+
       const onAbort = () => {
         cleanup();
         reject(new Error("ICE gathering aborted due to teardown"));
@@ -579,22 +651,122 @@ export class WebTorrentClient {
 
       timeoutId = setTimeout(() => {
         cleanup();
-        reject(new Error("ICE gathering timed out"));
+        resolve(); // Use whatever candidates we have gathered so far
       }, WebTorrentClient.#ICE_GATHERING_TIMEOUT);
 
       pc.addEventListener("icegatheringstatechange", onGatheringChange);
       pc.addEventListener("icecandidate", onIceCandidate);
+      pc.addEventListener("signalingstatechange", onSignalingChange);
       this.#destroyAbortController.signal.addEventListener("abort", onAbort);
     });
   }
 
-  /**
-   * Opaque destroyed check for use after `await` boundaries.
-   * Using a method call prevents TypeScript's control-flow narrowing
-   * from incorrectly eliminating the check as "always falsy".
-   */
-  #checkDestroyed(): boolean {
-    return this.#destroyed;
+  #waitForConnection(
+    pc: RTCPeerConnection,
+    channel?: RTCDataChannel,
+  ): Promise<RTCDataChannel> {
+    const { promise, resolve, reject } =
+      getPromiseWithResolvers<RTCDataChannel>();
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
+    let boundChannel: RTCDataChannel | undefined = channel;
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      pc.removeEventListener("iceconnectionstatechange", rejectIfTerminalState);
+      pc.removeEventListener("connectionstatechange", rejectIfTerminalState);
+      pc.removeEventListener("datachannel", onDataChannel);
+
+      if (boundChannel) {
+        boundChannel.removeEventListener("open", onChannelOpen);
+        boundChannel.removeEventListener("error", onChannelError);
+        boundChannel.removeEventListener("close", onChannelClose);
+        boundChannel.removeEventListener("closing", onChannelClose);
+      }
+      this.#destroyAbortController.signal.removeEventListener("abort", onAbort);
+    };
+
+    const rejectIfTerminalState = () => {
+      if (isTerminalConnectionState(pc.iceConnectionState)) {
+        cleanup();
+        reject(new Error(`ICE connection ${pc.iceConnectionState}`));
+        return true;
+      }
+      if (isTerminalConnectionState(pc.connectionState)) {
+        cleanup();
+        reject(new Error(`Connection state ${pc.connectionState}`));
+        return true;
+      }
+      return false;
+    };
+
+    const onChannelOpen = () => {
+      cleanup();
+      if (boundChannel) {
+        resolve(boundChannel);
+      } else {
+        reject(new Error("Data channel missing on open"));
+      }
+    };
+
+    const onChannelError = () => {
+      cleanup();
+      reject(new Error("Data channel error"));
+    };
+
+    const onChannelClose = () => {
+      cleanup();
+      reject(new Error("Data channel closed prematurely"));
+    };
+
+    const bindDataChannel = (dc: RTCDataChannel) => {
+      boundChannel = dc;
+      if (dc.readyState === "open") {
+        onChannelOpen();
+      } else if (dc.readyState === "closed" || dc.readyState === "closing") {
+        onChannelClose();
+      } else {
+        dc.addEventListener("open", onChannelOpen);
+        dc.addEventListener("error", onChannelError);
+        dc.addEventListener("close", onChannelClose);
+        dc.addEventListener("closing", onChannelClose);
+      }
+    };
+
+    const onDataChannel = (event: RTCDataChannelEvent) => {
+      if (!boundChannel) {
+        bindDataChannel(event.channel);
+      }
+    };
+
+    const onAbort = () => {
+      cleanup();
+      reject(new Error("Connection aborted due to teardown"));
+    };
+
+    if (this.#destroyAbortController.signal.aborted) {
+      onAbort();
+      return promise;
+    }
+
+    if (rejectIfTerminalState()) return promise;
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error("Data channel open timeout"));
+    }, this.#config.connectionTimeout);
+
+    pc.addEventListener("iceconnectionstatechange", rejectIfTerminalState);
+    pc.addEventListener("connectionstatechange", rejectIfTerminalState);
+    this.#destroyAbortController.signal.addEventListener("abort", onAbort);
+
+    if (boundChannel) {
+      bindDataChannel(boundChannel);
+    } else {
+      pc.addEventListener("datachannel", onDataChannel);
+    }
+
+    return promise;
   }
 
   #cleanupPendingOffer(offerId: string, pending?: PendingOffer): void {

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
@@ -488,16 +488,9 @@ export class WebTorrentClient {
     }
 
     let pc: RTCPeerConnection | undefined;
-    let remoteChannel: RTCDataChannel | undefined;
-
-    const onDataChannel = (event: RTCDataChannelEvent) => {
-      remoteChannel = event.channel;
-    };
-
     try {
       pc = new RTCPeerConnection(this.#config.rtcConfig);
       this.#negotiatingConnections.add(pc);
-      pc.addEventListener("datachannel", onDataChannel);
 
       await pc.setRemoteDescription(new RTCSessionDescription(offerSdp));
       this.#throwIfDestroyed();
@@ -527,8 +520,7 @@ export class WebTorrentClient {
 
       this.#wsClient.send(JSON.stringify(payload));
 
-      pc.removeEventListener("datachannel", onDataChannel);
-      const channel = await this.#waitForConnection(pc, remoteChannel);
+      const channel = await this.#waitForConnection(pc);
       this.#throwIfDestroyed();
 
       this.#eventTarget.dispatchEvent("peerConnected", {
@@ -537,10 +529,7 @@ export class WebTorrentClient {
         channel,
       });
     } catch (err: unknown) {
-      if (pc) {
-        pc.removeEventListener("datachannel", onDataChannel);
-        pc.close();
-      }
+      pc?.close();
       if (!this.#isDestroyed()) {
         this.#eventTarget.dispatchEvent("peerConnectFailed", {
           peerId: remotePeerId,

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
@@ -488,9 +488,16 @@ export class WebTorrentClient {
     }
 
     let pc: RTCPeerConnection | undefined;
+    let remoteChannel: RTCDataChannel | undefined;
+
+    const onDataChannel = (event: RTCDataChannelEvent) => {
+      remoteChannel = event.channel;
+    };
+
     try {
       pc = new RTCPeerConnection(this.#config.rtcConfig);
       this.#negotiatingConnections.add(pc);
+      pc.addEventListener("datachannel", onDataChannel);
 
       await pc.setRemoteDescription(new RTCSessionDescription(offerSdp));
       this.#throwIfDestroyed();
@@ -520,7 +527,8 @@ export class WebTorrentClient {
 
       this.#wsClient.send(JSON.stringify(payload));
 
-      const channel = await this.#waitForConnection(pc);
+      pc.removeEventListener("datachannel", onDataChannel);
+      const channel = await this.#waitForConnection(pc, remoteChannel);
       this.#throwIfDestroyed();
 
       this.#eventTarget.dispatchEvent("peerConnected", {
@@ -529,7 +537,10 @@ export class WebTorrentClient {
         channel,
       });
     } catch (err: unknown) {
-      pc?.close();
+      if (pc) {
+        pc.removeEventListener("datachannel", onDataChannel);
+        pc.close();
+      }
       if (!this.#isDestroyed()) {
         this.#eventTarget.dispatchEvent("peerConnectFailed", {
           peerId: remotePeerId,

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
@@ -54,7 +54,7 @@ interface WebTorrentClientConfig {
 
 - `peerConnected` (payload: `{ peerId: string, connection: RTCPeerConnection, channel: RTCDataChannel }`): Fired when the peer finishes WebRTC signaling and its Data Channel is successfully opened. The Swarm Manager takes immediate ownership.
 - `peerConnectFailed` (payload: `{ peerId: string, error: string }`): Fired if WebRTC SDP negotiation fails or the data channel fails to open after a peer has been claimed (e.g., ICE gathering timeout or connection timeout), allowing the manager to release the claim.
-- `warning` (payload: `string`): Fired if the tracker returns a warning.
+- `warning` (payload: `string`): Fired if the tracker returns a warning, or if the client encounters a local recoverable issue during signaling or offer/answer creation.
 - `error` (payload: `string`): Fired if the tracker returns an error, or if the underlying WebSocket encounters a failure.
 
 ---

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
@@ -11,7 +11,7 @@ The `WebTorrentClient` acts as a signaling layer using the `WebSocketClient` und
 1. **Strictly Browser Implementation**: Uses native browser `RTCPeerConnection` APIs without Node.js polyfills or dependencies.
 2. **Single Responsibility (SRP)**: Each instance manages exactly **one** WebSocket connection to a **single** tracker.
 3. **Early Deduplication**: To prevent duplicate peer connections across multiple tracker clients, it accepts a `claimPeer` callback to attempt to lock a `peer_id` for signaling, successfully deduplicating at the earliest possible stage.
-4. **Negotiate and Hand-Off**: The client handles WebRTC SDP signaling. The exact moment signaling finishes, it emits the negotiating objects to a higher layer (e.g., Swarm Manager) which takes ownership, waits for the connection to open, and handles the BitTorrent wire protocol.
+4. **Negotiate and Connect**: The client handles WebRTC SDP signaling and waits for the data channel to open. Once fully connected, it emits the connected objects to a higher layer (e.g., Swarm Manager) which takes ownership and handles the BitTorrent wire protocol.
 5. **Data Channel Configuration**: Matches the default behavior of the `bittorrent-tracker` (and `simple-peer`) npm packages, which create reliable, ordered Data Channels (empty `RTCDataChannelInit` config) unless explicitly overridden.
 6. **Optional WebSocket Pooling**: The `WebTorrentClient` does not create its own WebSocket connection. Instead, it accepts an injected `WebSocketClient` in its constructor. This allows higher layers to implement connection pooling (sharing a single WebSocket across multiple torrents to the same tracker) or manage the socket lifecycle independently.
 
@@ -30,11 +30,12 @@ interface WebTorrentClientConfig {
   channelConfig?: RTCDataChannelInit; // Optional Data Channel overrides
   offerTimeout?: number; // Time (in ms) to keep unanswered offers before destroying them. Default: 50000 (50s).
   offersCount?: number; // Maximum number of offers to generate per announce interval. Default: 5.
+  connectionTimeout?: number; // Time (in ms) to wait for the data channel to open. Default: 15000 (15s).
 
   // Callback invoked when a peer_id is discovered via an offer or answer.
-  // Attempts to claim the peer for the specified timeout duration.
+  // Attempts to claim the peer to prevent duplicate connections.
   // Return true to accept and connect, false if the peer is already claimed/connected.
-  claimPeer?: (peerId: string, timeout: number) => boolean;
+  claimPeer?: (peerId: string) => boolean;
 
   // Callback invoked before every announce to determine if new offers should be generated.
   // Return false to stop generating offers (numwant: 0), while still answering incoming offers.
@@ -51,8 +52,8 @@ interface WebTorrentClientConfig {
 
 ### Events
 
-- `peerSignaled` (payload: `{ peerId: string, connection: RTCPeerConnection, channel?: RTCDataChannel }`): Fired the exact moment WebRTC SDP signaling is complete. The Swarm Manager takes immediate ownership. Note: `channel` is only provided if we initiated the connection. If we received the offer, the Swarm Manager must listen for the `ondatachannel` event on the connection.
-- `peerSignalingFailed` (payload: `{ peerId: string, error: string }`): Fired if WebRTC SDP negotiation fails after a peer has been claimed (e.g., ICE gathering timeout or SDP application error), allowing the manager to release the claim.
+- `peerConnected` (payload: `{ peerId: string, connection: RTCPeerConnection, channel: RTCDataChannel }`): Fired when the peer finishes WebRTC signaling and its Data Channel is successfully opened. The Swarm Manager takes immediate ownership.
+- `peerConnectFailed` (payload: `{ peerId: string, error: string }`): Fired if WebRTC SDP negotiation fails or the data channel fails to open after a peer has been claimed (e.g., ICE gathering timeout or connection timeout), allowing the manager to release the claim.
 - `warning` (payload: `string`): Fired if the tracker returns a warning.
 - `error` (payload: `string`): Fired if the tracker returns an error, or if the underlying WebSocket encounters a failure.
 
@@ -64,8 +65,8 @@ interface WebTorrentClientConfig {
 
 Because the higher layer (e.g., Peer Manager) may spin up multiple `WebTorrentClient` instances for different public trackers, the same remote peer will likely be discovered multiple times. The client uses the injected `claimPeer` to deduplicate aggressively:
 
-1. **When Receiving an Offer:** The tracker JSON includes the remote `peer_id`. The client immediately calls `claimPeer(peer_id, offerTimeout)`. If it returns `false`, the client **ignores the JSON message entirely** and does not create an `RTCPeerConnection`.
-2. **When Receiving an Answer:** The tracker forwards an `answer` to a pending offer we sent. The JSON includes the remote `peer_id`. The client calls `claimPeer(peer_id, offerTimeout)`. If it returns `false`, the client **immediately closes** the pending `RTCPeerConnection` and discards the answer.
+1. **When Receiving an Offer:** The tracker JSON includes the remote `peer_id`. The client immediately calls `claimPeer(peer_id)`. If it returns `false`, the client **ignores the JSON message entirely** and does not create an `RTCPeerConnection`.
+2. **When Receiving an Answer:** The tracker forwards an `answer` to a pending offer we sent. The JSON includes the remote `peer_id`. The client calls `claimPeer(peer_id)`. If it returns `false`, the client **immediately closes** the pending `RTCPeerConnection` and discards the answer.
 
 ### Message Validation
 
@@ -182,7 +183,7 @@ Standard WebTorrent signaling **does not use Trickle ICE**. All ICE candidates m
 
 #### ICE Gathering Timeout
 
-ICE gathering can stall indefinitely if STUN/TURN servers are unreachable or the network is offline. To prevent this, the client enforces a **5-second timeout** on ICE gathering (matching `simple-peer`'s `ICECOMPLETE_TIMEOUT`). If gathering does not complete within 5 seconds, the promise is rejected and the caller closes the `RTCPeerConnection`. After any async ICE wait, the client also checks the `destroyed` flag to avoid acting on a torn-down instance.
+ICE gathering can stall indefinitely if STUN/TURN servers are unreachable or the network is offline. To prevent this, the client enforces a **5-second timeout** on ICE gathering (matching `simple-peer`'s `ICECOMPLETE_TIMEOUT`). If gathering does not complete within 5 seconds, the promise is resolved to use whatever candidates have been gathered so far. After any async ICE wait, the client also checks the `destroyed` flag to avoid acting on a torn-down instance.
 
 #### Initiating Connections (Sending Offers)
 
@@ -198,27 +199,25 @@ When generating offers, we do **not** know which peer will receive them. All off
 #### Receiving Offers
 
 1. The tracker sends an incoming `offer` originating from another peer. This payload **does** contain their `peer_id`.
-2. **Deduplication Check**: Call `claimPeer(peer_id, offerTimeout)`. Abort if `false`.
+2. **Deduplication Check**: Call `claimPeer(peer_id)`. Abort if `false`.
 3. The client creates a new `RTCPeerConnection` and calls `setRemoteDescription`.
 4. It creates an SDP answer, waits for ICE gathering, and sends it back to the tracker.
-5. **Immediate Hand-Off**: Signaling is complete. The client emits the `peerSignaled` event with `{ peerId, connection }` (no `channel` because it hasn't been established yet). The client forgets about this connection.
+5. **Wait for Connection**: Signaling is complete. The client waits for the data channel to open, then emits the `peerConnected` event with `{ peerId, connection, channel }`. The client then hands off ownership of the connection.
 
 #### Receiving Answers
 
 1. The tracker forwards an `answer` SDP to an `offer_id` we previously sent. This payload now reveals the remote `peer_id`.
-2. **Deduplication Check**: We finally know who answered! Call `claimPeer(peer_id, offerTimeout)`.
+2. **Deduplication Check**: We finally know who answered! Call `claimPeer(peer_id)`.
 3. If `claimPeer` returns `false` (we are already connected to them via another route), we look up the pending `RTCPeerConnection` by `offer_id`, immediately call `.close()`, clear the timeout, delete it, and abort.
 4. If `true`, the client applies `setRemoteDescription(answer)` to the pending connection and clears the timeout.
-5. **Immediate Hand-Off**: Signaling is complete. The client removes the connection from `pendingOffers` and emits the `peerSignaled` event with `{ peerId, connection, channel }`.
+5. **Wait for Connection**: Signaling is complete. The client removes the connection from `pendingOffers`, waits for the data channel to open, and emits the `peerConnected` event with `{ peerId, connection, channel }`.
 
-### Hand-Off (Strict SRP)
+### Hand-Off
 
-To maintain strict Single Responsibility, the `WebTorrentClient`'s job ends the exact millisecond the SDP negotiation finishes. It does **not** wait for the Data Channel to open, nor does it monitor ICE connection states. It emits the `peerSignaled` event and drops its internal reference.
+The `WebTorrentClient`'s job ends the exact millisecond the data channel is successfully opened. It emits the `peerConnected` event and drops its internal reference.
 
-The upper Peer Manager receives the negotiating objects and takes full responsibility for:
+The upper Peer Manager receives the connected objects and takes full responsibility for:
 
-1. If `channel` is provided (initiator), listening to `channel.onopen`.
-2. If `channel` is undefined (receiver), listening to `connection.ondatachannel` and then its `onopen` event.
-3. Listening to `connection.oniceconnectionstatechange` to detect failures.
-4. Setting timeouts for the connection attempt.
-5. Cleaning up its internal `connectingPeers` set if it fails.
+1. Listening to `channel.onclose` and `connection.onconnectionstatechange` to detect failures/drops.
+2. Handling the BitTorrent wire protocol messages over the data channel.
+3. Cleaning up its internal state if the connection closes.

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
@@ -1,20 +1,7 @@
 import { EventTarget } from "../../utils/event-target.js";
-import { getRTCErrorMessage } from "../utils.js";
+import { getRTCErrorMessage, isTerminalConnectionState } from "../utils.js";
 import { WebTorrentClient } from "../webtorrent-client/index.js";
 import { WebTorrentSocketPool } from "../webtorrent-socket-pool/index.js";
-
-const DATA_CHANNEL_TIMEOUT = 15000;
-
-function isTerminalConnectionState(
-  state: RTCIceConnectionState | RTCPeerConnectionState,
-): boolean {
-  // "disconnected" is technically a transient ICE state that can recover,
-  // but for live video streaming we treat it as terminal: dropping the peer
-  // immediately and reconnecting via the tracker is faster than waiting for
-  // a stale connection to potentially recover.
-
-  return state === "failed" || state === "closed" || state === "disconnected";
-}
 
 export interface WebTorrentManagerConfig {
   infoHash: string;
@@ -35,6 +22,7 @@ export type WebTorrentManagerEventMap = {
   }) => void;
   peerDisconnected: (event: {
     peerId: string;
+    trackerUrl: string;
     reason: string;
     isError: boolean;
   }) => void;
@@ -47,24 +35,10 @@ export type WebTorrentManagerEventMap = {
   error: (event: { trackerUrl: string; error: string }) => void;
 };
 
-type ConnectingPeer =
-  | {
-      status: "signaling";
-      timeoutId: ReturnType<typeof setTimeout>;
-      connection?: undefined;
-    }
-  | {
-      status: "connecting";
-      connection: RTCPeerConnection;
-      channel?: RTCDataChannel;
-      timeoutId: ReturnType<typeof setTimeout>;
-      trackerUrl: string;
-      cleanup: () => void;
-    };
-
 type ConnectedPeer = {
   connection: RTCPeerConnection;
   channel: RTCDataChannel;
+  trackerUrl: string;
   cleanup: () => void;
 };
 
@@ -72,7 +46,7 @@ export class WebTorrentManager {
   readonly #config: WebTorrentManagerConfig;
   readonly #eventTarget = new EventTarget<WebTorrentManagerEventMap>();
 
-  readonly #connectingPeers = new Map<string, ConnectingPeer>();
+  readonly #connectingPeers = new Set<string>();
   readonly #connectedPeers = new Map<string, ConnectedPeer>();
 
   readonly #clients = new Set<{
@@ -84,7 +58,7 @@ export class WebTorrentManager {
   #destroyed = false;
   #started = false;
 
-  #claimPeer = (remotePeerId: string, timeout: number): boolean => {
+  #claimPeer = (remotePeerId: string): boolean => {
     if (this.#destroyed) return false;
 
     if (
@@ -94,17 +68,7 @@ export class WebTorrentManager {
       return false;
     }
 
-    const timeoutId = setTimeout(() => {
-      const peer = this.#connectingPeers.get(remotePeerId);
-      if (peer?.status === "signaling") {
-        this.#connectingPeers.delete(remotePeerId);
-      }
-    }, timeout);
-
-    this.#connectingPeers.set(remotePeerId, {
-      status: "signaling",
-      timeoutId,
-    });
+    this.#connectingPeers.add(remotePeerId);
     return true;
   };
 
@@ -150,31 +114,30 @@ export class WebTorrentManager {
           throw error;
         }
 
-        const onPeerSignaled = (event: {
+        const onPeerConnected = (event: {
           peerId: string;
           connection: RTCPeerConnection;
-          channel?: RTCDataChannel;
+          channel: RTCDataChannel;
         }) => {
-          this.#handlePeerSignaled(
-            url,
+          this.#connectingPeers.delete(event.peerId);
+          this.#addConnectedPeer(
             event.peerId,
             event.connection,
             event.channel,
+            url,
           );
         };
 
-        const onPeerSignalingFailed = (event: {
+        const onPeerConnectFailed = (event: {
           peerId: string;
           error: string;
         }) => {
-          const peer = this.#connectingPeers.get(event.peerId);
-          if (peer?.status === "signaling") {
-            clearTimeout(peer.timeoutId);
+          if (this.#connectingPeers.has(event.peerId)) {
             this.#connectingPeers.delete(event.peerId);
             this.#eventTarget.dispatchEvent("peerConnectFailed", {
               peerId: event.peerId,
               trackerUrl: url,
-              error: `Signaling failed: ${event.error}`,
+              error: `Connection failed: ${event.error}`,
             });
           }
         };
@@ -190,17 +153,14 @@ export class WebTorrentManager {
           this.#eventTarget.dispatchEvent("error", { trackerUrl: url, error });
         };
 
-        client.addEventListener("peerSignaled", onPeerSignaled);
-        client.addEventListener("peerSignalingFailed", onPeerSignalingFailed);
+        client.addEventListener("peerConnected", onPeerConnected);
+        client.addEventListener("peerConnectFailed", onPeerConnectFailed);
         client.addEventListener("warning", onWarning);
         client.addEventListener("error", onError);
 
         const cleanupListeners = () => {
-          client.removeEventListener("peerSignaled", onPeerSignaled);
-          client.removeEventListener(
-            "peerSignalingFailed",
-            onPeerSignalingFailed,
-          );
+          client.removeEventListener("peerConnected", onPeerConnected);
+          client.removeEventListener("peerConnectFailed", onPeerConnectFailed);
           client.removeEventListener("warning", onWarning);
           client.removeEventListener("error", onError);
         };
@@ -233,14 +193,6 @@ export class WebTorrentManager {
     }
     this.#clients.clear();
 
-    for (const peer of this.#connectingPeers.values()) {
-      if (peer.status === "connecting") {
-        peer.cleanup();
-      } else {
-        clearTimeout(peer.timeoutId);
-      }
-      peer.connection?.close();
-    }
     this.#connectingPeers.clear();
 
     const connectedSnapshot = [...this.#connectedPeers.entries()];
@@ -251,6 +203,7 @@ export class WebTorrentManager {
       peer.connection.close();
       this.#eventTarget.dispatchEvent("peerDisconnected", {
         peerId,
+        trackerUrl: peer.trackerUrl,
         reason: "Manager destroyed",
         isError: false,
       });
@@ -269,177 +222,14 @@ export class WebTorrentManager {
       this.#connectedPeers.delete(peerId);
       this.#eventTarget.dispatchEvent("peerDisconnected", {
         peerId,
+        trackerUrl: connected.trackerUrl,
         reason,
         isError,
       });
     }
   }
 
-  #handlePeerSignaled(
-    trackerUrl: string,
-    peerId: string,
-    connection: RTCPeerConnection,
-    channel?: RTCDataChannel,
-  ): void {
-    if (this.#destroyed) {
-      connection.close();
-      return;
-    }
-
-    const signalingPeer = this.#connectingPeers.get(peerId);
-    if (!signalingPeer) {
-      // It might have been rejected/closed already
-      connection.close();
-      return;
-    }
-
-    if (signalingPeer.status === "connecting") {
-      connection.close();
-      return;
-    }
-
-    // Clear the signaling-phase timeout before replacing the map entry below.
-    // The timeout callback only deletes "signaling" entries, so it would be a
-    // harmless no-op if it fired after the transition to "connecting". However,
-    // clearing it eagerly avoids unnecessary timer retention.
-    clearTimeout(signalingPeer.timeoutId);
-
-    const connectingPeer: ConnectingPeer = {
-      status: "connecting",
-      connection,
-      channel,
-      trackerUrl,
-      timeoutId: setTimeout(() => {
-        fail("Data channel open timeout");
-      }, DATA_CHANNEL_TIMEOUT),
-      cleanup: () => cleanup(),
-    };
-
-    let onChannelOpenBound: (() => void) | null = null;
-    let onChannelErrorBound: (() => void) | null = null;
-    let onChannelCloseBound: (() => void) | null = null;
-
-    const onIceConnectionStateChange = () => {
-      checkAndFail(connection.iceConnectionState, "ICE connection");
-    };
-
-    const onConnectionStateChange = () => {
-      checkAndFail(connection.connectionState, "Connection state");
-    };
-
-    const onDataChannel = (event: RTCDataChannelEvent) => {
-      if (connectingPeer.channel) return;
-      connectingPeer.channel = event.channel;
-      bindDataChannel(event.channel);
-    };
-
-    const cleanup = () => {
-      clearTimeout(connectingPeer.timeoutId);
-      connection.removeEventListener(
-        "iceconnectionstatechange",
-        onIceConnectionStateChange,
-      );
-      connection.removeEventListener(
-        "connectionstatechange",
-        onConnectionStateChange,
-      );
-      connection.removeEventListener("datachannel", onDataChannel);
-      if (connectingPeer.channel) {
-        if (onChannelOpenBound) {
-          connectingPeer.channel.removeEventListener(
-            "open",
-            onChannelOpenBound,
-          );
-        }
-        if (onChannelErrorBound) {
-          connectingPeer.channel.removeEventListener(
-            "error",
-            onChannelErrorBound,
-          );
-        }
-        if (onChannelCloseBound) {
-          connectingPeer.channel.removeEventListener(
-            "close",
-            onChannelCloseBound,
-          );
-          connectingPeer.channel.removeEventListener(
-            "closing",
-            onChannelCloseBound,
-          );
-        }
-      }
-    };
-
-    this.#connectingPeers.set(peerId, connectingPeer);
-
-    const fail = (reason: string) => {
-      if (!this.#connectingPeers.delete(peerId)) return;
-      cleanup();
-      connection.close();
-      this.#eventTarget.dispatchEvent("peerConnectFailed", {
-        peerId,
-        trackerUrl,
-        error: reason,
-      });
-    };
-
-    const checkAndFail = (
-      state: RTCIceConnectionState | RTCPeerConnectionState,
-      prefix: string,
-    ) => {
-      if (isTerminalConnectionState(state)) {
-        fail(`${prefix} ${state}`);
-        return true;
-      }
-      return false;
-    };
-
-    if (checkAndFail(connection.iceConnectionState, "ICE connection")) return;
-    if (checkAndFail(connection.connectionState, "Connection state")) return;
-
-    connection.addEventListener(
-      "iceconnectionstatechange",
-      onIceConnectionStateChange,
-    );
-    connection.addEventListener(
-      "connectionstatechange",
-      onConnectionStateChange,
-    );
-
-    const onChannelOpen = (dataChannel: RTCDataChannel) => {
-      cleanup();
-      this.#connectingPeers.delete(peerId);
-      this.#promoteToConnected(peerId, connection, dataChannel, trackerUrl);
-    };
-
-    const bindDataChannel = (dataChannel: RTCDataChannel) => {
-      if (dataChannel.readyState === "open") {
-        onChannelOpen(dataChannel);
-      } else if (
-        dataChannel.readyState === "closed" ||
-        dataChannel.readyState === "closing"
-      ) {
-        fail("Data channel closed prematurely");
-      } else {
-        onChannelOpenBound = () => onChannelOpen(dataChannel);
-        onChannelErrorBound = () => fail("Data channel error");
-        onChannelCloseBound = () => fail("Data channel closed prematurely");
-
-        dataChannel.addEventListener("open", onChannelOpenBound);
-        dataChannel.addEventListener("error", onChannelErrorBound);
-        dataChannel.addEventListener("close", onChannelCloseBound);
-        dataChannel.addEventListener("closing", onChannelCloseBound);
-      }
-    };
-
-    if (channel) {
-      bindDataChannel(channel);
-    } else {
-      connection.addEventListener("datachannel", onDataChannel);
-    }
-  }
-
-  #promoteToConnected(
+  #addConnectedPeer(
     peerId: string,
     connection: RTCPeerConnection,
     channel: RTCDataChannel,
@@ -510,6 +300,7 @@ export class WebTorrentManager {
     this.#connectedPeers.set(peerId, {
       connection,
       channel,
+      trackerUrl,
       cleanup,
     });
 

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
@@ -184,7 +184,7 @@ export class WebTorrentManager {
     this.#destroyed = true;
 
     // Remove our listeners BEFORE destroying the client. This ensures that
-    // if client.destroy() synchronously dispatches events (e.g. peerSignaled),
+    // if client.destroy() synchronously dispatches events,
     // they won't reach this already-destroyed manager.
     for (const { client, releaseSocket, cleanupListeners } of this.#clients) {
       cleanupListeners();

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/spec.md
@@ -42,7 +42,7 @@ interface WebTorrentManagerConfig {
 The Manager aggregates events from all child clients and forwards/handles them.
 
 - `peerConnected` (payload: `{ peerId: string, connection: RTCPeerConnection, channel: RTCDataChannel, trackerUrl: string, close: (error?: string) => void }`): Fired when a peer finishes WebRTC signaling on _any_ tracker and its Data Channel is successfully opened.
-- `peerDisconnected` (payload: `{ peerId: string, reason: string, isError: boolean }`): Fired when a fully connected peer is closed, either due to an unexpected disconnect (e.g., network loss), manager destruction, or a manual call to the peer's `close` callback.
+- `peerDisconnected` (payload: `{ peerId: string, trackerUrl: string, reason: string, isError: boolean }`): Fired when a fully connected peer is closed, either due to an unexpected disconnect (e.g., network loss), manager destruction, or a manual call to the peer's `close` callback.
 - `peerConnectFailed` (payload: `{ peerId: string, trackerUrl: string, error: string }`): Fired if a signaled peer fails to connect or its data channel fails to open.
 - `warning` (payload: `{ trackerUrl: string, warning: string }`): Aggregated tracker warnings.
 - `error` (payload: `{ trackerUrl: string, error: string }`): Aggregated tracker errors (both WebSocket level and WebTorrent level).
@@ -64,7 +64,7 @@ To adhere to the Single Source of Truth principle, the `WebTorrentManager` avoid
 It passes a bound `#claimPeer` callback into every `WebTorrentClient` it creates:
 
 ```typescript
-#claimPeer = (remotePeerId: string, timeout: number): boolean => {
+#claimPeer = (remotePeerId: string): boolean => {
   if (this.#destroyed) return false;
 
   if (
@@ -74,37 +74,19 @@ It passes a bound `#claimPeer` callback into every `WebTorrentClient` it creates
     return false;
   }
 
-  const timeoutId = setTimeout(() => {
-    const peer = this.#connectingPeers.get(remotePeerId);
-    if (peer?.status === "signaling") {
-      this.#connectingPeers.delete(remotePeerId);
-    }
-  }, timeout);
-
-  this.#connectingPeers.set(remotePeerId, {
-    status: "signaling",
-    timeoutId,
-  });
+  this.#connectingPeers.add(remotePeerId);
   return true;
 };
 ```
 
-_Note: If the WebRTC signaling fails (e.g. ICE gathering timeout), the `WebTorrentClient` emits a `peerSignalingFailed` event, and the Manager automatically cleans up the `"signaling"` state to allow future reconnection attempts. If the connection fails after signaling, or the upper layer rejects the peer later, the upper layer must invoke the `close()` callback (provided in the `peerConnected` payload) to cleanly close the connection and remove it from the internal collections._
+_Note: If the WebRTC connection fails (e.g. ICE gathering timeout or data channel timeout), the `WebTorrentClient` emits a `peerConnectFailed` event, and the Manager automatically deletes the peer from `#connectingPeers` to allow future reconnection attempts. If the connection fails after being fully established, or the upper layer rejects the peer later, the upper layer must invoke the `close()` callback (provided in the `peerConnected` payload) to cleanly close the connection and remove it from the internal collections._
 
 ### Peer Connection Lifecycle
 
-When a child `WebTorrentClient` emits a `peerSignaled` event, the Manager transitions the peer from the `"signaling"` state to the `"connecting"` state. It updates the entry in the `#connectingPeers` map with the actual `RTCPeerConnection` and starts listening to both `RTCPeerConnection` state events (`connectionstatechange`, `iceconnectionstatechange`) and the `RTCDataChannel` state.
+The `WebTorrentClient` fully encapsulates the WebRTC negotiation and data channel establishment. 
 
-#### Terminal States
-
-For live video streaming, the manager treats certain transient or failing states as terminal:
-
-- `failed`, `closed`, and `disconnected` states on either `connectionState` or `iceConnectionState` are treated as immediate terminal failure states. Dropping the peer immediately and reconnecting via a tracker is faster than waiting for a stale/disconnected connection to potentially recover.
-
-A **15-second timeout** (`DATA_CHANNEL_TIMEOUT`) is applied to wait for the data channel to fully open.
-
-- If the data channel successfully opens (or is already open) within the timeout, the Manager removes the peer from `#connectingPeers`, stores it in `#connectedPeers` (promoting it to `"connected"`), and dispatches the `peerConnected` event.
-- If the connection times out, enters a terminal state, or the data channel fails/closes prematurely, the Manager cleans up, closes the connection, deletes the peer from `#connectingPeers`, and dispatches a `peerConnectFailed` event.
+- If a peer successfully completes WebRTC signaling and its Data Channel opens, the client emits a `peerConnected` event. The Manager removes the peer from `#connectingPeers`, stores it in `#connectedPeers`, and dispatches its own `peerConnected` event upstream.
+- If a peer fails to connect (either during signaling or while waiting for the data channel), the client emits a `peerConnectFailed` event. The Manager removes the peer from `#connectingPeers` and forwards the `peerConnectFailed` event upstream.
 
 #### Connected Peer Lifecycle
 


### PR DESCRIPTION
This PR refactors the WebRTC peer connection establishment and state tracking logic within `p2p-media-loader-core`. 

### Key Changes:
- **`WebTorrentClient` Encapsulation:** Moves WebRTC signaling, data channel establishment, and connection/ICE state monitoring inside `WebTorrentClient`. It now handles timeouts and emits `peerConnected` when the data channel opens.
- **`WebTorrentManager` Simplification:** Removes connection-phase state machines, redundant timeouts, and ICE tracking from `WebTorrentManager`, making it strictly responsible for aggregative tracker and active peer wire management.
- **Specification Alignment:** Updated the `spec.md` files for both client and manager to reflect the latest implementation and state behaviors (such as including `trackerUrl` in `peerDisconnected` and resolving ICE gathering timeouts with gathered candidates).
- **Invariants Protection:** Added try-catch guards to `EventTarget` to prevent user-land listener errors from throwing and breaking internal state changes.

All TypeScript and ESLint checks pass successfully.