### PR TITLE
feat: Improve older browser compatibility (Chrome 66+)

### DIFF
--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -169,7 +169,7 @@ export class HybridLoader {
     }
 
     this.isProcessQueueMicrotaskCreated = true;
-    queueMicrotask(() => {
+    Utils.queueMicrotask(() => {
       try {
         this.processQueue();
         this.lastQueueProcessingTimeStamp = now;

--- a/packages/p2p-media-loader-core/src/p2p/loader.ts
+++ b/packages/p2p-media-loader-core/src/p2p/loader.ts
@@ -318,7 +318,7 @@ export class P2PLoader {
   #sendSegmentsAnnouncement = (sendEmptyAnnouncement = false) => {
     this.#isAnnounceMicrotaskCreated = true;
 
-    queueMicrotask(() => {
+    Utils.queueMicrotask(() => {
       const { loaded = [], httpLoading = [] } = sendEmptyAnnouncement
         ? {}
         : this.#getSegmentsAnnouncement();

--- a/packages/p2p-media-loader-core/src/utils/utils.ts
+++ b/packages/p2p-media-loader-core/src/utils/utils.ts
@@ -17,6 +17,10 @@ export function getPromiseWithResolvers<T = void>() {
   };
 }
 
+export function queueMicrotask(fn: () => void): void {
+  void Promise.resolve().then(fn);
+}
+
 export function joinChunks(chunks: Uint8Array[], totalBytes?: number) {
   totalBytes ??= chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
 

--- a/packages/p2p-media-loader-core/src/webtorrent/utils.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/utils.ts
@@ -20,7 +20,7 @@ export function getRTCErrorMessage(
 }
 
 export function isTerminalConnectionState(
-  state: RTCIceConnectionState | RTCPeerConnectionState,
+  state: RTCIceConnectionState,
 ): boolean {
   // "disconnected" is technically a transient ICE state that can recover,
   // but for live video streaming we treat it as terminal: dropping the peer

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/index.ts
@@ -674,7 +674,6 @@ export class WebTorrentClient {
     const cleanup = () => {
       clearTimeout(timeoutId);
       pc.removeEventListener("iceconnectionstatechange", rejectIfTerminalState);
-      pc.removeEventListener("connectionstatechange", rejectIfTerminalState);
       pc.removeEventListener("datachannel", onDataChannel);
 
       if (boundChannel) {
@@ -690,11 +689,6 @@ export class WebTorrentClient {
       if (isTerminalConnectionState(pc.iceConnectionState)) {
         cleanup();
         reject(new Error(`ICE connection ${pc.iceConnectionState}`));
-        return true;
-      }
-      if (isTerminalConnectionState(pc.connectionState)) {
-        cleanup();
-        reject(new Error(`Connection state ${pc.connectionState}`));
         return true;
       }
       return false;
@@ -757,7 +751,6 @@ export class WebTorrentClient {
     }, this.#config.connectionTimeout);
 
     pc.addEventListener("iceconnectionstatechange", rejectIfTerminalState);
-    pc.addEventListener("connectionstatechange", rejectIfTerminalState);
     this.#destroyAbortController.signal.addEventListener("abort", onAbort);
 
     if (boundChannel) {

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-client/spec.md
@@ -8,7 +8,7 @@ The `WebTorrentClient` acts as a signaling layer using the `WebSocketClient` und
 
 **Key Design Decisions:**
 
-1. **Strictly Browser Implementation**: Uses native browser `RTCPeerConnection` APIs without Node.js polyfills or dependencies.
+1. **Strictly Browser Implementation**: Uses native browser `RTCPeerConnection` APIs without Node.js polyfills or dependencies. Designed to support older browsers (down to Chrome 66+, legacy Safari, and older Smart TVs) by avoiding `RTCPeerConnection.connectionState` and using `queueMicrotask` fallback via Promises.
 2. **Single Responsibility (SRP)**: Each instance manages exactly **one** WebSocket connection to a **single** tracker.
 3. **Early Deduplication**: To prevent duplicate peer connections across multiple tracker clients, it accepts a `claimPeer` callback to attempt to lock a `peer_id` for signaling, successfully deduplicating at the earliest possible stage.
 4. **Negotiate and Connect**: The client handles WebRTC SDP signaling and waits for the data channel to open. Once fully connected, it emits the connected objects to a higher layer (e.g., Swarm Manager) which takes ownership and handles the BitTorrent wire protocol.
@@ -218,6 +218,6 @@ The `WebTorrentClient`'s job ends the exact millisecond the data channel is succ
 
 The upper Peer Manager receives the connected objects and takes full responsibility for:
 
-1. Listening to `channel.onclose` and `connection.onconnectionstatechange` to detect failures/drops.
+1. Listening to `channel.onclose` and `connection.oniceconnectionstatechange` to detect failures/drops.
 2. Handling the BitTorrent wire protocol messages over the data channel.
 3. Cleaning up its internal state if the connection closes.

--- a/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
+++ b/packages/p2p-media-loader-core/src/webtorrent/webtorrent-manager/index.ts
@@ -236,7 +236,6 @@ export class WebTorrentManager {
     trackerUrl: string,
   ): void {
     if (
-      isTerminalConnectionState(connection.connectionState) ||
       isTerminalConnectionState(connection.iceConnectionState)
     ) {
       connection.close();
@@ -250,15 +249,6 @@ export class WebTorrentManager {
 
     const onDisconnect = (reason: string, isError: boolean) =>
       this.#closePeer(peerId, reason, isError);
-
-    const onConnectionStateChange = () => {
-      if (isTerminalConnectionState(connection.connectionState)) {
-        onDisconnect(
-          `Connection state became ${connection.connectionState}`,
-          true,
-        );
-      }
-    };
 
     const onIceConnectionStateChange = () => {
       if (isTerminalConnectionState(connection.iceConnectionState)) {
@@ -285,10 +275,6 @@ export class WebTorrentManager {
     const cleanup = () => {
       closeRef = null;
       connection.removeEventListener(
-        "connectionstatechange",
-        onConnectionStateChange,
-      );
-      connection.removeEventListener(
         "iceconnectionstatechange",
         onIceConnectionStateChange,
       );
@@ -304,10 +290,6 @@ export class WebTorrentManager {
       cleanup,
     });
 
-    connection.addEventListener(
-      "connectionstatechange",
-      onConnectionStateChange,
-    );
     connection.addEventListener(
       "iceconnectionstatechange",
       onIceConnectionStateChange,


### PR DESCRIPTION
This Pull Request removes RTCPeerConnection.connectionState / connectionstatechange and replaces queueMicrotask with a custom Promise-based utility to ensure complete compatibility with older browsers, legacy Safari, and legacy Smart TVs. All tests and builds are fully passing.