### PR TITLE
feat(core): add tracker URL to onTrackerWarning and onTrackerError events

### DIFF
--- a/packages/p2p-media-loader-core/src/p2p/loader.ts
+++ b/packages/p2p-media-loader-core/src/p2p/loader.ts
@@ -104,6 +104,7 @@ export class P2PLoader {
         event.warning,
       );
       this.#eventTarget.getEventDispatcher("onTrackerWarning")({
+        trackerUrl: event.trackerUrl,
         streamType: this.#stream.type,
         warning: new Error(event.warning),
       });
@@ -115,6 +116,7 @@ export class P2PLoader {
         event.error,
       );
       this.#eventTarget.getEventDispatcher("onTrackerError")({
+        trackerUrl: event.trackerUrl,
         streamType: this.#stream.type,
         error: new Error(event.error),
       });

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -553,6 +553,8 @@ export type PeerErrorDetails = {
 
 /** Represents the details of a tracker error event. */
 export type TrackerErrorDetails = {
+  /** The tracker URL. */
+  trackerUrl: string;
   /** The type of stream that the tracker is for. */
   streamType: StreamType;
   /** The error that occurred during the tracker request. */
@@ -560,6 +562,8 @@ export type TrackerErrorDetails = {
 };
 
 export type TrackerWarningDetails = {
+  /** The tracker URL. */
+  trackerUrl: string;
   /** The type of stream that the tracker is for. */
   streamType: StreamType;
   /** The warning that occurred during the tracker request. */


### PR DESCRIPTION
This PR adds the tracker URL parameter to the `onTrackerWarning` and `onTrackerError` events/callbacks API.

### Changes:
- **`packages/p2p-media-loader-core/src/types.ts`**: Added `trackerUrl: string;` parameter to `TrackerErrorDetails` and `TrackerWarningDetails` type definitions.
- **`packages/p2p-media-loader-core/src/p2p/loader.ts`**: Passed the `trackerUrl` from the underlying WebTorrent manager events upstream to the dispatched event payloads.