### PR TITLE
feat: enrich API events with infoHash and streamType context

### DIFF
--- a/packages/p2p-media-loader-core/src/http-loader.ts
+++ b/packages/p2p-media-loader-core/src/http-loader.ts
@@ -157,7 +157,13 @@ export class HttpRequestExecutor {
         }
         const value = new Uint8Array(arrayBuffer);
         requestControls.addLoadedChunk(value);
-        this.onChunkDownloaded(value.byteLength, "http");
+        this.onChunkDownloaded(
+          value.byteLength,
+          "http",
+          undefined,
+          segment.stream.type,
+          this.request.infoHash,
+        );
       } else {
         const reader = response.body.getReader();
         activeReader = reader;
@@ -172,7 +178,13 @@ export class HttpRequestExecutor {
             throw new DOMException("Request aborted", "AbortError");
           }
           requestControls.addLoadedChunk(value);
-          this.onChunkDownloaded(value.byteLength, "http");
+          this.onChunkDownloaded(
+            value.byteLength,
+            "http",
+            undefined,
+            segment.stream.type,
+            this.request.infoHash,
+          );
         }
       }
 

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -62,6 +62,7 @@ export class HybridLoader {
       this.playback,
       this.config,
       this.eventTarget,
+      this.swarmId,
     );
 
     this.p2pLoaders = new P2PLoadersContainer(

--- a/packages/p2p-media-loader-core/src/p2p/loader.ts
+++ b/packages/p2p-media-loader-core/src/p2p/loader.ts
@@ -27,6 +27,7 @@ export class P2PLoader {
   #isAnnounceMicrotaskCreated = false;
   readonly #webtorrentManagerLogger = debug("p2pml-core:webtorrent-manager");
 
+  readonly #infoHash: string;
   #streamManifestUrl: string;
   readonly #stream: StreamWithSegments;
   readonly #requests: RequestsContainer;
@@ -35,6 +36,13 @@ export class P2PLoader {
   readonly #webTorrentSocketPool: WebTorrentSocketPool;
   readonly #eventTarget: EventTarget<EventTargetMap>;
   readonly #onSegmentAnnouncement: () => void;
+
+  readonly #onPeerConnect: CoreEventMap["onPeerConnect"];
+  readonly #onPeerConnectError: CoreEventMap["onPeerConnectError"];
+  readonly #onPeerClose: CoreEventMap["onPeerClose"];
+  readonly #onPeerError: CoreEventMap["onPeerError"];
+  readonly #onTrackerWarning: CoreEventMap["onTrackerWarning"];
+  readonly #onTrackerError: CoreEventMap["onTrackerError"];
 
   constructor(
     streamManifestUrl: string,
@@ -55,6 +63,13 @@ export class P2PLoader {
     this.#eventTarget = eventTarget;
     this.#onSegmentAnnouncement = onSegmentAnnouncement;
 
+    this.#onPeerConnect = eventTarget.getEventDispatcher("onPeerConnect");
+    this.#onPeerConnectError = eventTarget.getEventDispatcher("onPeerConnectError");
+    this.#onPeerClose = eventTarget.getEventDispatcher("onPeerClose");
+    this.#onPeerError = eventTarget.getEventDispatcher("onPeerError");
+    this.#onTrackerWarning = eventTarget.getEventDispatcher("onTrackerWarning");
+    this.#onTrackerError = eventTarget.getEventDispatcher("onTrackerError");
+
     this.#swarmId = this.#config.swarmId ?? this.#streamManifestUrl;
     this.#streamSwarmId = StreamUtils.getStreamSwarmId(
       this.#swarmId,
@@ -62,6 +77,8 @@ export class P2PLoader {
     );
 
     const streamHash = PeerUtil.getStreamHash(this.#streamSwarmId);
+    this.#infoHash = streamHash;
+
     let peerId = P2PLoader.#PEER_ID_BY_INFO_HASH.get(streamHash);
     if (!peerId) {
       peerId = PeerUtil.generatePeerId(this.#config.trackerClientVersionPrefix);
@@ -91,9 +108,11 @@ export class P2PLoader {
         `Peer connection failed (${event.peerId}) from tracker ${event.trackerUrl}:`,
         event.error,
       );
-      this.#eventTarget.getEventDispatcher("onPeerError")({
+      this.#onPeerConnectError({
         peerId: event.peerId,
+        infoHash: this.#infoHash,
         streamType: this.#stream.type,
+        trackerUrl: event.trackerUrl,
         error: new Error(event.error),
       });
     });
@@ -103,8 +122,9 @@ export class P2PLoader {
         `Tracker warning (${event.trackerUrl}):`,
         event.warning,
       );
-      this.#eventTarget.getEventDispatcher("onTrackerWarning")({
+      this.#onTrackerWarning({
         trackerUrl: event.trackerUrl,
+        infoHash: this.#infoHash,
         streamType: this.#stream.type,
         warning: new Error(event.warning),
       });
@@ -115,8 +135,9 @@ export class P2PLoader {
         `Tracker error (${event.trackerUrl}):`,
         event.error,
       );
-      this.#eventTarget.getEventDispatcher("onTrackerError")({
+      this.#onTrackerError({
         trackerUrl: event.trackerUrl,
+        infoHash: this.#infoHash,
         streamType: this.#stream.type,
         error: new Error(event.error),
       });
@@ -259,13 +280,21 @@ export class P2PLoader {
         },
         onSegmentsAnnouncement: this.#onSegmentAnnouncement,
       },
-      this.#config,
+      {
+        p2pNotReceivingBytesTimeoutMs: this.#config.p2pNotReceivingBytesTimeoutMs,
+        webRtcMaxMessageSize: this.#config.webRtcMaxMessageSize,
+        p2pErrorRetries: this.#config.p2pErrorRetries,
+        validateP2PSegment: this.#config.validateP2PSegment,
+        streamType: this.#stream.type,
+        infoHash: this.#infoHash,
+      },
       this.#eventTarget,
     );
     this.#peersMap.set(event.peerId, peer);
 
-    this.#eventTarget.getEventDispatcher("onPeerConnect")({
+    this.#onPeerConnect({
       peerId: event.peerId,
+      infoHash: this.#infoHash,
       streamType: this.#stream.type,
     });
 
@@ -291,15 +320,17 @@ export class P2PLoader {
     peer.destroy(true);
 
     if (event.isError) {
-      this.#eventTarget.getEventDispatcher("onPeerError")({
+      this.#onPeerError({
         peerId: event.peerId,
+        infoHash: this.#infoHash,
         streamType: this.#stream.type,
         error: new Error(event.reason),
       });
     }
 
-    this.#eventTarget.getEventDispatcher("onPeerClose")({
+    this.#onPeerClose({
       peerId: peer.id,
+      infoHash: this.#infoHash,
       streamType: this.#stream.type,
     });
   };
@@ -384,11 +415,16 @@ export class P2PLoader {
       this.broadcastAnnouncement,
     );
 
+    // webtorrentManager.destroy() internally clears its event target and dispatches
+    // synchronous "peerDisconnected" events for active peers. These events trigger
+    // our #onPeerDisconnectedWebTorrent handler, which destroys peer wrappers and
+    // removes them from #peersMap. We destroy webtorrentManager first to prevent
+    // redundant WebRTC connection closing calls during the manual peer cleanup loop.
+    this.#webtorrentManager.destroy();
+
     for (const peer of this.#peersMap.values()) {
       peer.destroy();
     }
     this.#peersMap.clear();
-
-    this.#webtorrentManager.destroy();
   }
 }

--- a/packages/p2p-media-loader-core/src/p2p/peer-protocol.ts
+++ b/packages/p2p-media-loader-core/src/p2p/peer-protocol.ts
@@ -1,5 +1,5 @@
 import debug from "debug";
-import { CoreEventMap, StreamConfig } from "../types.js";
+import { CoreEventMap, StreamConfig, StreamType } from "../types.js";
 import * as Command from "./commands/index.js";
 import { EventTarget } from "../utils/event-target.js";
 import { DataChannelSender } from "../webtorrent/data-channel-sender.js";
@@ -10,7 +10,7 @@ export type PeerConfig = Pick<
   | "webRtcMaxMessageSize"
   | "p2pErrorRetries"
   | "validateP2PSegment"
->;
+> & { streamType: StreamType; infoHash: string };
 
 const logger = debug("p2pml-core:peer-protocol");
 
@@ -66,7 +66,13 @@ export class PeerProtocol {
       this.#receivingCommandBytes(data);
     } else {
       this.#eventHandlers.onSegmentChunkReceived(data);
-      this.#onChunkDownloaded(data.byteLength, "p2p", this.#peerId);
+      this.#onChunkDownloaded(
+        data.byteLength,
+        "p2p",
+        this.#peerId,
+        this.#peerConfig.streamType,
+        this.#peerConfig.infoHash,
+      );
     }
   };
 
@@ -115,7 +121,12 @@ export class PeerProtocol {
 
     try {
       await this.#dataChannelSender.sendData(data, (chunkSize) => {
-        this.#onChunkUploaded(chunkSize, this.#peerId);
+        this.#onChunkUploaded(
+          chunkSize,
+          this.#peerId,
+          this.#peerConfig.streamType,
+          this.#peerConfig.infoHash,
+        );
       });
     } finally {
       if (this.#uploadingRequestId === requestId) {

--- a/packages/p2p-media-loader-core/src/requests/request-container.ts
+++ b/packages/p2p-media-loader-core/src/requests/request-container.ts
@@ -2,6 +2,8 @@ import { Playback, BandwidthCalculators } from "../internal-types.js";
 import { CoreEventMap, SegmentWithStream, StreamConfig } from "../types.js";
 import { EventTarget } from "../utils/event-target.js";
 import { Request } from "./request.js";
+import * as StreamUtils from "../utils/stream.js";
+import * as PeerUtil from "../utils/peer.js";
 
 export class RequestsContainer {
   private readonly requests = new Map<SegmentWithStream, Request>();
@@ -12,6 +14,7 @@ export class RequestsContainer {
     private readonly playback: Playback,
     private readonly config: StreamConfig,
     private readonly eventTarget: EventTarget<CoreEventMap>,
+    private readonly swarmId: string,
   ) {}
 
   get executingHttpCount() {
@@ -37,6 +40,8 @@ export class RequestsContainer {
   getOrCreateRequest(segment: SegmentWithStream) {
     let request = this.requests.get(segment);
     if (!request) {
+      const streamSwarmId = StreamUtils.getStreamSwarmId(this.swarmId, segment.stream);
+      const infoHash = PeerUtil.getStreamHash(streamSwarmId);
       request = new Request(
         segment,
         this.requestProcessQueueCallback,
@@ -44,6 +49,7 @@ export class RequestsContainer {
         this.playback,
         this.config,
         this.eventTarget,
+        infoHash,
       );
       this.requests.set(segment, request);
     }

--- a/packages/p2p-media-loader-core/src/requests/request.ts
+++ b/packages/p2p-media-loader-core/src/requests/request.ts
@@ -78,6 +78,7 @@ export class Request {
   private _abortRequestCallback?: (
     error: RequestError<RequestAbortErrorType>,
   ) => void;
+  private notReceivingBytesTimeoutMs?: number;
   private readonly _logger: debug.Debugger;
   private _isHandledByProcessQueue = false;
   private readonly onSegmentError: CoreEventMap["onSegmentError"];
@@ -92,6 +93,7 @@ export class Request {
     private readonly playback: Playback,
     private readonly playbackConfig: StreamUtils.PlaybackTimeWindowsConfig,
     eventTarget: EventTarget<CoreEventMap>,
+    readonly infoHash: string,
   ) {
     this.onSegmentError = eventTarget.getEventDispatcher("onSegmentError");
     this.onSegmentAbort = eventTarget.getEventDispatcher("onSegmentAbort");
@@ -303,6 +305,7 @@ export class Request {
 
     const { notReceivingBytesTimeoutMs, abort } = controls;
     this._abortRequestCallback = abort;
+    this.notReceivingBytesTimeoutMs = notReceivingBytesTimeoutMs;
 
     if (notReceivingBytesTimeoutMs !== undefined) {
       this.notReceivingBytesTimeout.start(notReceivingBytesTimeoutMs);
@@ -317,6 +320,8 @@ export class Request {
       downloadSource: requestData.downloadSource,
       peerId:
         requestData.downloadSource === "p2p" ? requestData.peerId : undefined,
+      infoHash: this.infoHash,
+      streamType: this.segment.stream.type,
     });
 
     return {
@@ -341,6 +346,7 @@ export class Request {
         this.currentAttempt?.downloadSource === "p2p"
           ? this.currentAttempt.peerId
           : undefined,
+      infoHash: this.infoHash,
       streamType: this.segment.stream.type,
     });
     this._abortRequestCallback = undefined;
@@ -350,7 +356,17 @@ export class Request {
 
   private abortOnTimeout = () => {
     this.throwErrorIfNotLoadingStatus();
-    if (!this.currentAttempt) return;
+    if (!this.currentAttempt || !this.progress || this.notReceivingBytesTimeoutMs === undefined) return;
+
+    const now = performance.now();
+    const lastActive = this.progress.lastLoadedChunkTimestamp ?? this.progress.startTimestamp;
+    const msSinceLastActive = now - lastActive;
+
+    if (msSinceLastActive < this.notReceivingBytesTimeoutMs) {
+      // False alarm! The stream is still downloading. Reschedule the timer.
+      this.notReceivingBytesTimeout.restart(this.notReceivingBytesTimeoutMs - msSinceLastActive);
+      return;
+    }
 
     const error = new RequestError("bytes-receiving-timeout");
     this._abortRequestCallback?.(error);
@@ -383,6 +399,7 @@ export class Request {
         this.currentAttempt.downloadSource === "p2p"
           ? this.currentAttempt.peerId
           : undefined,
+      infoHash: this.infoHash,
       streamType: this.segment.stream.type,
     });
     this.notReceivingBytesTimeout.clear();
@@ -400,12 +417,14 @@ export class Request {
     this._totalBytes = this._loadedBytes;
     this.onSegmentLoaded({
       segmentUrl: this.segment.url,
+      segment: mapSegmentWithStreamToSegment(this.segment),
       bytesLength: this.data.byteLength,
       downloadSource: this.currentAttempt.downloadSource,
       peerId:
         this.currentAttempt.downloadSource === "p2p"
           ? this.currentAttempt.peerId
           : undefined,
+      infoHash: this.infoHash,
       streamType: this.segment.stream.type,
     });
 
@@ -418,7 +437,6 @@ export class Request {
   private addLoadedChunk = (chunk: Uint8Array) => {
     this.throwErrorIfNotLoadingStatus();
     if (!this.currentAttempt || !this.progress) return;
-    this.notReceivingBytesTimeout.restart();
 
     const { byteLength } = chunk;
     const { all: allBC, http: httpBC } = this.bandwidthCalculators;
@@ -435,7 +453,6 @@ export class Request {
 
   private firstBytesReceived = () => {
     this.throwErrorIfNotLoadingStatus();
-    this.notReceivingBytesTimeout.restart();
   };
 
   private throwErrorIfNotLoadingStatus() {
@@ -504,9 +521,9 @@ export class Timeout {
   }
 
   restart(ms?: number) {
-    if (this.timeoutId) clearTimeout(this.timeoutId);
-    if (ms) this.ms = ms;
-    if (!this.ms) return;
+    this.clear();
+    if (ms !== undefined) this.ms = ms;
+    if (this.ms === undefined) return;
     this.timeoutId = window.setTimeout(this.action, this.ms);
   }
 

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -480,6 +480,12 @@ export type SegmentStartDetails = {
 
   /** The peer ID, if the segment is downloaded from a peer. */
   peerId: string | undefined;
+
+  /** The info hash of the swarm that the segment belongs to. */
+  infoHash: string;
+
+  /** The type of stream that the segment is associated with. */
+  streamType: StreamType;
 };
 
 /** Represents details about a segment error event. */
@@ -496,6 +502,9 @@ export type SegmentErrorDetails = {
   /** The peer ID, if the segment was downloaded from a peer. */
   peerId: string | undefined;
 
+  /** The info hash of the swarm that the segment belongs to. */
+  infoHash: string;
+
   /** The type of stream that the segment is associated with. */
   streamType: StreamType;
 };
@@ -511,14 +520,23 @@ export type SegmentAbortDetails = {
   /** The peer ID, if the segment was downloaded from a peer. */
   peerId: string | undefined;
 
+  /** The info hash of the swarm that the segment belongs to. */
+  infoHash: string;
+
   /** The type of stream that the segment is associated with. */
   streamType: StreamType;
 };
 
 /** Represents the details about a loaded segment. */
 export type SegmentLoadDetails = {
-  /** The URL of the loaded segment */
+  /**
+   * The URL of the loaded segment
+   * @deprecated Use `segment.url` instead
+   */
   segmentUrl: string;
+
+  /** The segment that the event is about. */
+  segment: Segment;
 
   /** The length of the segment in bytes. */
   bytesLength: number;
@@ -529,7 +547,10 @@ export type SegmentLoadDetails = {
   /** The peer ID, if the segment was downloaded from a peer. */
   peerId: string | undefined;
 
-  /** The segment that the event is about. */
+  /** The info hash of the swarm that the segment belongs to. */
+  infoHash: string;
+
+  /** The type of stream that the segment is associated with. */
   streamType: StreamType;
 };
 
@@ -537,6 +558,8 @@ export type SegmentLoadDetails = {
 export type PeerDetails = {
   /** The unique identifier for a peer in the network. */
   peerId: string;
+  /** The info hash of the swarm that the peer is part of. */
+  infoHash: string;
   /** The type of stream that the peer is connected to. */
   streamType: StreamType;
 };
@@ -545,6 +568,8 @@ export type PeerDetails = {
 export type PeerErrorDetails = {
   /** The unique identifier for a peer in the network. */
   peerId: string;
+  /** The info hash of the swarm that the peer is part of. */
+  infoHash: string;
   /** The type of stream that the peer is connected to. */
   streamType: StreamType;
   /** The error that occurred during the peer-to-peer connection. */
@@ -555,6 +580,8 @@ export type PeerErrorDetails = {
 export type TrackerErrorDetails = {
   /** The tracker URL. */
   trackerUrl: string;
+  /** The info hash of the swarm that the tracker is for. */
+  infoHash: string;
   /** The type of stream that the tracker is for. */
   streamType: StreamType;
   /** The error that occurred during the tracker request. */
@@ -564,10 +591,26 @@ export type TrackerErrorDetails = {
 export type TrackerWarningDetails = {
   /** The tracker URL. */
   trackerUrl: string;
+  /** The info hash of the swarm that the tracker is for. */
+  infoHash: string;
   /** The type of stream that the tracker is for. */
   streamType: StreamType;
   /** The warning that occurred during the tracker request. */
   warning: unknown;
+};
+
+/** Represents the details of a peer connection error event. */
+export type PeerConnectErrorDetails = {
+  /** The unique identifier for a peer in the network. */
+  peerId: string;
+  /** The info hash of the swarm that the peer is connected to. */
+  infoHash: string;
+  /** The type of stream that the peer is connected to. */
+  streamType: StreamType;
+  /** The tracker URL that the peer was discovered from. */
+  trackerUrl: string;
+  /** The error that occurred during the peer-to-peer connection. */
+  error: Error;
 };
 
 /**
@@ -611,6 +654,13 @@ export type CoreEventMap = {
   onPeerConnect: (params: PeerDetails) => void;
 
   /**
+   * Triggered when an error occurs while establishing a peer-to-peer connection.
+   *
+   * @param params - Contains details about the connection error and the peer.
+   */
+  onPeerConnectError: (params: PeerConnectErrorDetails) => void;
+
+  /**
    * Triggered when an existing peer-to-peer connection is closed.
    *
    * @param params - Contains details about the peer that the event is about.
@@ -624,26 +674,41 @@ export type CoreEventMap = {
    */
   onPeerError: (params: PeerErrorDetails) => void;
 
+  // Positional parameters instead of an object to avoid allocation on every
+  // chunk — this is a high-frequency event and allocations increase GC pressure.
   /**
    * Invoked after a chunk of data from a segment has been successfully downloaded.
    *
    * @param bytesLength - The size of the downloaded chunk in bytes.
    * @param downloadSource - The source of the download.
    * @param peerId - The peer ID of the peer that the event is about, if applicable.
+   * @param streamType - The type of stream that the chunk belongs to.
+   * @param infoHash - The info hash of the swarm that the chunk belongs to.
    */
   onChunkDownloaded: (
     bytesLength: number,
     downloadSource: DownloadSource,
-    peerId?: string,
+    peerId: string | undefined,
+    streamType: StreamType,
+    infoHash: string,
   ) => void;
 
+  // Positional parameters instead of an object to avoid allocation on every
+  // chunk — this is a high-frequency event and allocations increase GC pressure.
   /**
    * Called when a chunk of data has been successfully uploaded to a peer.
    *
    * @param bytesLength - The length of the segment in bytes.
    * @param peerId - The peer ID, if the segment was downloaded from a peer
+   * @param streamType - The type of stream that the chunk belongs to.
+   * @param infoHash - The info hash of the swarm that the chunk belongs to.
    */
-  onChunkUploaded: (bytesLength: number, peerId: string) => void;
+  onChunkUploaded: (
+    bytesLength: number,
+    peerId: string,
+    streamType: StreamType,
+    infoHash: string,
+  ) => void;
 
   /**
    * Called when an error occurs during the tracker request process.

--- a/packages/p2p-media-loader-core/src/utils/event-target.ts
+++ b/packages/p2p-media-loader-core/src/utils/event-target.ts
@@ -1,40 +1,61 @@
 export class EventTarget<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  EventTypesMap extends Record<string, (...args: any[]) => unknown>,
+  EventTypesMap extends Record<
+    string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (a1?: any, a2?: any, a3?: any, a4?: any, a5?: any) => unknown
+  >,
 > {
   private events = new Map<
     keyof EventTypesMap,
     EventTypesMap[keyof EventTypesMap][]
   >();
 
+  // We use hardcoded positional arguments (a1, a2, etc.) instead of TypeScript rest parameters
+  // (...args) to avoid hidden array allocations during high-frequency event dispatching.
+  // This ensures zero heap allocation for critical path events like onChunkDownloaded.
+  //
+  // IMPORTANT: Maximum supported arity is 5. If an event handler ever needs more than
+  // 5 parameters, add additional positional arguments (a6, a7, ...) here AND in
+  // getEventDispatcher below.
   public dispatchEvent<K extends keyof EventTypesMap>(
     eventName: K,
     ...args: Parameters<EventTypesMap[K]>
+  ): void;
+  public dispatchEvent<K extends keyof EventTypesMap>(
+    eventName: K,
+    a1?: unknown,
+    a2?: unknown,
+    a3?: unknown,
+    a4?: unknown,
+    a5?: unknown,
   ) {
     const listeners = this.events.get(eventName);
     if (!listeners) return;
-    for (const listener of [...listeners]) {
+    for (const listener of listeners) {
       try {
-        listener(...args);
+        listener(a1, a2, a3, a4, a5);
       } catch {
         // Swallow user-land errors to protect internal invariants
       }
     }
   }
 
+  public getEventDispatcher<K extends keyof EventTypesMap>(
+    eventName: K,
+  ): (...args: Parameters<EventTypesMap[K]>) => void;
   public getEventDispatcher<K extends keyof EventTypesMap>(eventName: K) {
-    let listeners = this.events.get(eventName);
-    if (!listeners) {
-      listeners = [];
-      this.events.set(eventName, listeners);
-    }
-
-    const definedListeners = listeners;
-
-    return (...args: Parameters<EventTypesMap[K]>) => {
-      for (const listener of [...definedListeners]) {
+    return (
+      a1?: unknown,
+      a2?: unknown,
+      a3?: unknown,
+      a4?: unknown,
+      a5?: unknown,
+    ) => {
+      const listeners = this.events.get(eventName);
+      if (!listeners) return;
+      for (const listener of listeners) {
         try {
-          listener(...args);
+          listener(a1, a2, a3, a4, a5);
         } catch {
           // Swallow user-land errors to protect internal invariants
         }
@@ -50,7 +71,11 @@ export class EventTarget<
     if (!listeners) {
       this.events.set(eventName, [listener]);
     } else {
-      listeners.push(listener);
+      // Copy-on-write: we MUST create a new array here instead of mutating (e.g. push()).
+      // dispatchEvent/getEventDispatcher iterate the array directly (no snapshot copy)
+      // for zero-allocation dispatch. Creating a new array ensures any in-progress
+      // iteration sees a stable reference and is not affected by concurrent additions.
+      this.events.set(eventName, [...listeners, listener]);
     }
   }
 
@@ -59,12 +84,21 @@ export class EventTarget<
     listener: EventTypesMap[K],
   ) {
     const listeners = this.events.get(eventName);
-    if (listeners) {
-      const index = listeners.indexOf(listener);
-      if (index !== -1) {
-        listeners.splice(index, 1);
-      }
+    if (!listeners) return;
+
+    const index = listeners.indexOf(listener);
+    if (index === -1) return;
+
+    if (listeners.length === 1) {
+      this.events.delete(eventName);
+      return;
     }
+
+    // Copy-on-write: manually slice and splice to avoid closure allocation
+    // and maintain stable references for in-progress iterations.
+    const newListeners = listeners.slice();
+    newListeners.splice(index, 1);
+    this.events.set(eventName, newListeners);
   }
 
   public clear(): void {

--- a/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
+++ b/packages/p2p-media-loader-demo/src/components/P2PVideoDemo.tsx
@@ -57,6 +57,11 @@ const playerComponents = {
   vidstack_hls: HlsjsVidstack,
 } as const;
 
+type PeerState = {
+  peerId: string;
+  infoHash: string;
+};
+
 export const P2PVideoDemo = ({
   streamUrl,
   debugToolsEnabled = false,
@@ -74,7 +79,12 @@ export const P2PVideoDemo = ({
     [queryParams.trackers],
   );
 
-  const [peers, setPeers] = useState<string[]>([]);
+  const [peers, setPeers] = useState<PeerState[]>([]);
+
+  const uniquePeerIds = useMemo(
+    () => Array.from(new Set(peers.map((p) => p.peerId))),
+    [peers],
+  );
 
   const onChunkDownloaded = useCallback(
     (bytesLength: number, downloadSource: string) => {
@@ -100,7 +110,7 @@ export const P2PVideoDemo = ({
     if (params.streamType !== "main") return;
 
     setPeers((peers) => {
-      return [...peers, params.peerId];
+      return [...peers, { peerId: params.peerId, infoHash: params.infoHash }];
     });
   }, []);
 
@@ -108,7 +118,10 @@ export const P2PVideoDemo = ({
     if (params.streamType !== "main") return;
 
     setPeers((peers) => {
-      return peers.filter((peer) => peer !== params.peerId);
+      return peers.filter(
+        (peer) =>
+          !(peer.peerId === params.peerId && peer.infoHash === params.infoHash),
+      );
     });
   }, []);
 
@@ -163,7 +176,7 @@ export const P2PVideoDemo = ({
             />
           </div>
 
-          <NodeNetwork peers={peers} />
+          <NodeNetwork peers={uniquePeerIds} />
 
           {trackers.length > 0 && (
             <div className="trackers-container">


### PR DESCRIPTION
## Summary

Adds `infoHash` and `streamType` context to all public API events, introduces a new `onPeerConnectError` event, and optimizes the `EventTarget` class for zero-allocation high-frequency event dispatch.

## Changes

### Event Enrichment
- Add `infoHash` and `streamType` to all segment events (`onSegmentStart`, `onSegmentLoaded`, `onSegmentError`, `onSegmentAbort`)
- Add `infoHash` to peer events (`onPeerConnect`, `onPeerClose`, `onPeerError`) and tracker events (`onTrackerWarning`, `onTrackerError`)
- Add `segment` object to `SegmentLoadDetails`; deprecate `segmentUrl` field
- Make `streamType` and `infoHash` required (non-optional) on `onChunkDownloaded` and `onChunkUploaded`

### New Event
- `onPeerConnectError`: fires when WebRTC connection establishment fails, includes `trackerUrl` for diagnostics (split from `onPeerError`)

### Performance Optimizations
- **EventTarget**: use positional args instead of rest params, and copy-on-write arrays instead of snapshot copies, for zero heap allocation on high-frequency event dispatch
- **P2PLoader**: cache event dispatchers in constructor fields to avoid per-call closure allocation
- **Request timeout**: validate actual elapsed time in `abortOnTimeout` to prevent false-alarm aborts from timer drift

### Bug Fixes
- **P2PLoader destroy ordering**: destroy `webtorrentManager` before manual peer cleanup to prevent redundant WebRTC connection close calls
- **Timeout.restart**: use strict `undefined` checks to eliminate falsy-zero confusion

### Demo
- Track peers by `(peerId, infoHash)` composite key to correctly handle the same peer appearing in multiple swarms

## Breaking Changes

- `onPeerError` no longer fires for WebRTC connection *establishment* failures — use `onPeerConnectError` instead
- `onChunkDownloaded` and `onChunkUploaded` signatures now have `streamType` and `infoHash` as required (non-optional) parameters
- `PeerConnectErrorDetails` is a new exported type