### PR TITLE
Refactor: use a single peer ID across all swarms

### DIFF
--- a/packages/p2p-media-loader-core/src/core.ts
+++ b/packages/p2p-media-loader-core/src/core.ts
@@ -26,7 +26,7 @@ import {
   deepCopy,
   filterUndefinedProps,
 } from "./utils/utils.js";
-import { TRACKER_CLIENT_VERSION_PREFIX } from "./utils/peer.js";
+import { TRACKER_CLIENT_VERSION_PREFIX, generatePeerId } from "./utils/peer.js";
 import { SegmentStorage } from "./segment-storage/index.js";
 import { WebTorrentSocketPool } from "./webtorrent/webtorrent-socket-pool/index.js";
 
@@ -86,6 +86,7 @@ export class Core<TStream extends Stream = Stream> {
   private readonly socketPoolLogger = debug(
     "p2pml-core:webtorrent-socket-pool",
   );
+  private readonly peerId: string;
   private mainStreamLoader?: HybridLoader;
   private secondaryStreamLoader?: HybridLoader;
   private streamDetails: StreamDetails = {
@@ -130,6 +131,10 @@ export class Core<TStream extends Stream = Stream> {
       baseConfig: filteredConfig,
       specificStreamConfig: filteredConfig.secondaryStream,
     });
+
+    this.peerId = generatePeerId(
+      this.mainStreamConfig.trackerClientVersionPrefix,
+    );
 
     this.webTorrentSocketPool.addEventListener("error", (error, url) => {
       this.socketPoolLogger(`WebSocket error for tracker url ${url}:`, error);
@@ -556,6 +561,7 @@ export class Core<TStream extends Stream = Stream> {
       this.segmentStorage,
       this.webTorrentSocketPool,
       this.eventTarget,
+      this.peerId,
     );
   }
 }

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -51,6 +51,7 @@ export class HybridLoader {
     private readonly segmentStorage: SegmentStorage,
     private readonly webTorrentSocketPool: WebTorrentSocketPool,
     private readonly eventTarget: EventTarget<CoreEventMap>,
+    private readonly peerId: string,
   ) {
     const activeStream = this.lastRequestedSegment.stream;
     this.swarmId = this.config.swarmId ?? this.streamManifestUrl;
@@ -73,6 +74,7 @@ export class HybridLoader {
       this.config,
       this.webTorrentSocketPool,
       this.eventTarget,
+      this.peerId,
       this.requestProcessQueueMicrotask,
     );
 

--- a/packages/p2p-media-loader-core/src/p2p/loader.ts
+++ b/packages/p2p-media-loader-core/src/p2p/loader.ts
@@ -19,7 +19,6 @@ export type EventTargetMap = Record<`onStorageUpdated-${string}`, () => void> &
   CoreEventMap;
 
 export class P2PLoader {
-  static readonly #PEER_ID_BY_INFO_HASH = new Map<string, string>();
   readonly #webtorrentManager: WebTorrentManager;
   readonly #peersMap = new Map<string, Peer>();
   readonly #swarmId: string;
@@ -52,6 +51,7 @@ export class P2PLoader {
     config: StreamConfig,
     webTorrentSocketPool: WebTorrentSocketPool,
     eventTarget: EventTarget<EventTargetMap>,
+    peerId: string,
     onSegmentAnnouncement: () => void,
   ) {
     this.#streamManifestUrl = streamManifestUrl;
@@ -78,12 +78,6 @@ export class P2PLoader {
 
     const streamHash = PeerUtil.getStreamHash(this.#streamSwarmId);
     this.#infoHash = streamHash;
-
-    let peerId = P2PLoader.#PEER_ID_BY_INFO_HASH.get(streamHash);
-    if (!peerId) {
-      peerId = PeerUtil.generatePeerId(this.#config.trackerClientVersionPrefix);
-      P2PLoader.#PEER_ID_BY_INFO_HASH.set(streamHash, peerId);
-    }
 
     this.#webtorrentManager = new WebTorrentManager({
       infoHash: streamHash,

--- a/packages/p2p-media-loader-core/src/p2p/loaders-container.ts
+++ b/packages/p2p-media-loader-core/src/p2p/loaders-container.ts
@@ -30,6 +30,7 @@ export class P2PLoadersContainer {
   readonly #config: StreamConfig;
   readonly #webTorrentSocketPool: WebTorrentSocketPool;
   readonly #eventTarget: EventTarget<CoreEventMap>;
+  readonly #peerId: string;
   #onSegmentAnnouncement: () => void;
 
   constructor(
@@ -40,6 +41,7 @@ export class P2PLoadersContainer {
     config: StreamConfig,
     webTorrentSocketPool: WebTorrentSocketPool,
     eventTarget: EventTarget<CoreEventMap>,
+    peerId: string,
     onSegmentAnnouncement: () => void,
   ) {
     this.#streamManifestUrl = streamManifestUrl;
@@ -48,6 +50,7 @@ export class P2PLoadersContainer {
     this.#config = config;
     this.#webTorrentSocketPool = webTorrentSocketPool;
     this.#eventTarget = eventTarget;
+    this.#peerId = peerId;
     this.#onSegmentAnnouncement = onSegmentAnnouncement;
 
     this.#currentLoaderItem = this.#findOrCreateLoaderForStream(stream);
@@ -68,6 +71,7 @@ export class P2PLoadersContainer {
       this.#config,
       this.#webTorrentSocketPool,
       this.#eventTarget,
+      this.#peerId,
       () => {
         if (this.#currentLoaderItem.loader === loader) {
           this.#onSegmentAnnouncement();


### PR DESCRIPTION
This refactoring generates a single `peerId` at the `Core` level and injects it down to the `P2PLoader` instances. This prevents a memory leak where the static `PEER_ID_BY_INFO_HASH` grew indefinitely. It also unifies the behavior so that the same peer ID is used across both video and audio swarms, aligning with tracker optimizations.