### PR TITLE
Refactor: use a single peer ID across all swarms and make tracker prefix global

### DIFF
--- a/packages/p2p-media-loader-core/src/core.ts
+++ b/packages/p2p-media-loader-core/src/core.ts
@@ -26,7 +26,7 @@ import {
   deepCopy,
   filterUndefinedProps,
 } from "./utils/utils.js";
-import { TRACKER_CLIENT_VERSION_PREFIX } from "./utils/peer.js";
+import { TRACKER_CLIENT_VERSION_PREFIX, generatePeerId } from "./utils/peer.js";
 import { SegmentStorage } from "./segment-storage/index.js";
 import { WebTorrentSocketPool } from "./webtorrent/webtorrent-socket-pool/index.js";
 
@@ -36,6 +36,7 @@ export class Core<TStream extends Stream = Stream> {
   static readonly DEFAULT_COMMON_CORE_CONFIG: CommonCoreConfig = {
     segmentMemoryStorageLimit: undefined,
     customSegmentStorageFactory: undefined,
+    trackerClientVersionPrefix: TRACKER_CLIENT_VERSION_PREFIX,
   };
 
   /** Default configuration for stream settings. */
@@ -54,7 +55,6 @@ export class Core<TStream extends Stream = Stream> {
     httpNotReceivingBytesTimeoutMs: 3000,
     httpErrorRetries: 3,
     p2pErrorRetries: 3,
-    trackerClientVersionPrefix: TRACKER_CLIENT_VERSION_PREFIX,
     announceTrackers: [
       "wss://tracker.novage.com.ua",
       "wss://tracker.openwebtorrent.com",
@@ -86,6 +86,7 @@ export class Core<TStream extends Stream = Stream> {
   private readonly socketPoolLogger = debug(
     "p2pml-core:webtorrent-socket-pool",
   );
+  private readonly peerId: string;
   private mainStreamLoader?: HybridLoader;
   private secondaryStreamLoader?: HybridLoader;
   private streamDetails: StreamDetails = {
@@ -130,6 +131,10 @@ export class Core<TStream extends Stream = Stream> {
       baseConfig: filteredConfig,
       specificStreamConfig: filteredConfig.secondaryStream,
     });
+
+    this.peerId = generatePeerId(
+      this.commonCoreConfig.trackerClientVersionPrefix,
+    );
 
     this.webTorrentSocketPool.addEventListener("error", (error, url) => {
       this.socketPoolLogger(`WebSocket error for tracker url ${url}:`, error);
@@ -556,6 +561,7 @@ export class Core<TStream extends Stream = Stream> {
       this.segmentStorage,
       this.webTorrentSocketPool,
       this.eventTarget,
+      this.peerId,
     );
   }
 }

--- a/packages/p2p-media-loader-core/src/hybrid-loader.ts
+++ b/packages/p2p-media-loader-core/src/hybrid-loader.ts
@@ -51,6 +51,7 @@ export class HybridLoader {
     private readonly segmentStorage: SegmentStorage,
     private readonly webTorrentSocketPool: WebTorrentSocketPool,
     private readonly eventTarget: EventTarget<CoreEventMap>,
+    private readonly peerId: string,
   ) {
     const activeStream = this.lastRequestedSegment.stream;
     this.swarmId = this.config.swarmId ?? this.streamManifestUrl;
@@ -73,6 +74,7 @@ export class HybridLoader {
       this.config,
       this.webTorrentSocketPool,
       this.eventTarget,
+      this.peerId,
       this.requestProcessQueueMicrotask,
     );
 

--- a/packages/p2p-media-loader-core/src/p2p/loader.ts
+++ b/packages/p2p-media-loader-core/src/p2p/loader.ts
@@ -19,7 +19,6 @@ export type EventTargetMap = Record<`onStorageUpdated-${string}`, () => void> &
   CoreEventMap;
 
 export class P2PLoader {
-  static readonly #PEER_ID_BY_INFO_HASH = new Map<string, string>();
   readonly #webtorrentManager: WebTorrentManager;
   readonly #peersMap = new Map<string, Peer>();
   readonly #swarmId: string;
@@ -52,6 +51,7 @@ export class P2PLoader {
     config: StreamConfig,
     webTorrentSocketPool: WebTorrentSocketPool,
     eventTarget: EventTarget<EventTargetMap>,
+    peerId: string,
     onSegmentAnnouncement: () => void,
   ) {
     this.#streamManifestUrl = streamManifestUrl;
@@ -78,12 +78,6 @@ export class P2PLoader {
 
     const streamHash = PeerUtil.getStreamHash(this.#streamSwarmId);
     this.#infoHash = streamHash;
-
-    let peerId = P2PLoader.#PEER_ID_BY_INFO_HASH.get(streamHash);
-    if (!peerId) {
-      peerId = PeerUtil.generatePeerId(this.#config.trackerClientVersionPrefix);
-      P2PLoader.#PEER_ID_BY_INFO_HASH.set(streamHash, peerId);
-    }
 
     this.#webtorrentManager = new WebTorrentManager({
       infoHash: streamHash,

--- a/packages/p2p-media-loader-core/src/p2p/loaders-container.ts
+++ b/packages/p2p-media-loader-core/src/p2p/loaders-container.ts
@@ -30,6 +30,7 @@ export class P2PLoadersContainer {
   readonly #config: StreamConfig;
   readonly #webTorrentSocketPool: WebTorrentSocketPool;
   readonly #eventTarget: EventTarget<CoreEventMap>;
+  readonly #peerId: string;
   #onSegmentAnnouncement: () => void;
 
   constructor(
@@ -40,6 +41,7 @@ export class P2PLoadersContainer {
     config: StreamConfig,
     webTorrentSocketPool: WebTorrentSocketPool,
     eventTarget: EventTarget<CoreEventMap>,
+    peerId: string,
     onSegmentAnnouncement: () => void,
   ) {
     this.#streamManifestUrl = streamManifestUrl;
@@ -48,6 +50,7 @@ export class P2PLoadersContainer {
     this.#config = config;
     this.#webTorrentSocketPool = webTorrentSocketPool;
     this.#eventTarget = eventTarget;
+    this.#peerId = peerId;
     this.#onSegmentAnnouncement = onSegmentAnnouncement;
 
     this.#currentLoaderItem = this.#findOrCreateLoaderForStream(stream);
@@ -68,6 +71,7 @@ export class P2PLoadersContainer {
       this.#config,
       this.#webTorrentSocketPool,
       this.#eventTarget,
+      this.#peerId,
       () => {
         if (this.#currentLoaderItem.loader === loader) {
           this.#onSegmentAnnouncement();

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -148,6 +148,17 @@ export type CommonCoreConfig = {
    * ```
    */
   customSegmentStorageFactory?: (isLive: boolean) => SegmentStorage;
+
+  /**
+   * Prefix to use for the WebTorrent client version in tracker communications.
+   * If undefined, the default version prefix is used, which is calculated based on the package version.
+   *
+   * @default
+   * ```typescript
+   * trackerClientVersionPrefix: undefined
+   * ```
+   */
+  trackerClientVersionPrefix: string;
 };
 
 /**
@@ -382,17 +393,6 @@ export type StreamConfig = {
    * ```
    */
   rtcConfig: RTCConfiguration;
-
-  /**
-   * Prefix to use for the WebTorrent client version in tracker communications.
-   * If undefined, the default version prefix is used, which is calculated based on the package version.
-   *
-   * @default
-   * ```typescript
-   * trackerClientVersionPrefix: undefined
-   * ```
-   */
-  trackerClientVersionPrefix: string;
 
   /**
    * Optional unique identifier for the swarm, used to isolate peer pools by media stream.

--- a/packages/p2p-media-loader-core/src/types.ts
+++ b/packages/p2p-media-loader-core/src/types.ts
@@ -151,11 +151,10 @@ export type CommonCoreConfig = {
 
   /**
    * Prefix to use for the WebTorrent client version in tracker communications.
-   * If undefined, the default version prefix is used, which is calculated based on the package version.
    *
    * @default
    * ```typescript
-   * trackerClientVersionPrefix: undefined
+   * trackerClientVersionPrefix: `-PM${formattedPackageVersion}-`
    * ```
    */
   trackerClientVersionPrefix: string;

--- a/packages/p2p-media-loader-core/test/utils.test.ts
+++ b/packages/p2p-media-loader-core/test/utils.test.ts
@@ -38,6 +38,7 @@ test("override configs", () => {
 test("override common config", () => {
   const commonConfig: CommonCoreConfig = {
     segmentMemoryStorageLimit: 1200,
+    trackerClientVersionPrefix: "PM1000",
   };
 
   const coreConfig: CoreConfig = {
@@ -73,6 +74,7 @@ test("override common config", () => {
 
   const result: Partial<CommonCoreConfig> = {
     segmentMemoryStorageLimit: undefined,
+    trackerClientVersionPrefix: "PM1000",
   };
 
   expect(
@@ -96,7 +98,6 @@ test("override defined stream config", () => {
     httpNotReceivingBytesTimeoutMs: 1000,
     httpErrorRetries: 3,
     p2pErrorRetries: 3,
-    trackerClientVersionPrefix: "PM1000",
     announceTrackers: [
       "wss://tracker.webtorrent.dev",
       "wss://tracker.files.fm:7073/announce",
@@ -152,7 +153,6 @@ test("override defined stream config", () => {
     httpNotReceivingBytesTimeoutMs: 1500,
     httpErrorRetries: 2,
     p2pErrorRetries: 4,
-    trackerClientVersionPrefix: "PM1000",
     announceTrackers: [
       "wss://tracker.webtorrent.dev",
       "wss://tracker.files.fm:7073/announce",


### PR DESCRIPTION
This refactoring generates a single `peerId` at the `Core` level and injects it down to the `P2PLoader` instances. This prevents a memory leak where the static `PEER_ID_BY_INFO_HASH` grew indefinitely. Additionally, `trackerClientVersionPrefix` has been moved from the stream-specific config to the global `CommonCoreConfig`, ensuring consistency across the entire client instance. This architectural change also guarantees compatibility with tracker implementations that require a single peer ID per WebSocket connection.