### PR TITLE
Fix remaining issues reported by ai-bughunter

### DIFF
--- a/packages/p2p-media-loader-core/src/segment-storage/utils.ts
+++ b/packages/p2p-media-loader-core/src/segment-storage/utils.ts
@@ -7,4 +7,5 @@ export const isIPadOrIPhone = (userAgent: string) =>
   /iPad|iPhone/i.test(userAgent);
 
 export const isAndroidWebview = (userAgent: string) =>
-  /Android/i.test(userAgent) && !/Chrome|Firefox/i.test(userAgent);
+  /Android/i.test(userAgent) &&
+  (/; wv\)/i.test(userAgent) || !/Chrome|Firefox/i.test(userAgent));

--- a/packages/p2p-media-loader-core/src/utils/stream.ts
+++ b/packages/p2p-media-loader-core/src/utils/stream.ts
@@ -129,6 +129,7 @@ export function getSegmentAvgDuration(stream: StreamWithSegments) {
   const { segments } = stream;
   let sumDuration = 0;
   const { size } = segments;
+  if (size === 0) return 0;
   for (const segment of segments.values()) {
     const duration = segment.endTime - segment.startTime;
     sumDuration += duration;

--- a/packages/p2p-media-loader-core/test/binary-serialization.test.ts
+++ b/packages/p2p-media-loader-core/test/binary-serialization.test.ts
@@ -70,7 +70,9 @@ describe("binary-serialization", () => {
     });
 
     it("should throw an error when deserializing an empty buffer", () => {
-      expect(() => deserializeInt(new Uint8Array(0))).toThrow("Buffer is too short");
+      expect(() => deserializeInt(new Uint8Array(0))).toThrow(
+        "Buffer is too short",
+      );
     });
 
     it("should correctly serialize and deserialize zero", () => {
@@ -83,13 +85,17 @@ describe("binary-serialization", () => {
     it("should throw an error when metadata has zero byte length", () => {
       // Crafted byte: SerializedItem.Int (0) << 4 | 0 = 0x00
       const malformed = new Uint8Array([0x00]);
-      expect(() => deserializeInt(malformed)).toThrow("Invalid integer: zero byte length");
+      expect(() => deserializeInt(malformed)).toThrow(
+        "Invalid integer: zero byte length",
+      );
     });
 
     it("should throw an error when byte length exceeds 7 bytes", () => {
       // Crafted byte: SerializedItem.Int (0) << 4 | 8 = 0x08
       const malformed = new Uint8Array([0x08, 1, 2, 3, 4, 5, 6, 7, 8]);
-      expect(() => deserializeInt(malformed)).toThrow("Invalid integer: byte length exceeds safe integer limit");
+      expect(() => deserializeInt(malformed)).toThrow(
+        "Invalid integer: byte length exceeds safe integer limit",
+      );
     });
   });
 

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsMediaElement.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsMediaElement.tsx
@@ -30,6 +30,7 @@ export const HlsjsMediaElement = ({
 
     containerRef.current.appendChild(videoContainer);
 
+    const prevHls = window.Hls;
     window.Hls = HlsJsP2PEngine.injectMixin(Hls);
 
     // @ts-ignore
@@ -56,7 +57,7 @@ export const HlsjsMediaElement = ({
     player.load();
 
     return () => {
-      window.Hls = undefined;
+      window.Hls = prevHls;
       player?.remove();
       videoContainer.remove();
     };
@@ -68,7 +69,6 @@ export const HlsjsMediaElement = ({
     onPeerConnect,
     onPeerClose,
     streamUrl,
-    
   ]);
 
   return isHlsSupported ? (

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsOpenPlayer.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsOpenPlayer.tsx
@@ -19,6 +19,7 @@ export const HlsjsOpenPlayer = ({
   useEffect(() => {
     if (!playerContainerRef.current || !Hls.isSupported()) return;
 
+    const prevHls = window.Hls;
     window.Hls = HlsJsP2PEngine.injectMixin(Hls);
 
     let isCleanedUp = false;
@@ -35,7 +36,7 @@ export const HlsjsOpenPlayer = ({
       player?.destroy();
       videoElement.remove();
       videoContainer.remove();
-      window.Hls = undefined;
+      window.Hls = prevHls;
     };
 
     const initPlayer = async () => {

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsPlyr.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsPlyr.tsx
@@ -45,24 +45,27 @@ export const HlsjsPlyr = ({
     hls.on(Hls.Events.MANIFEST_PARSED, () => {
       const { levels } = hls;
 
-      const quality: PlyrModule.Options["quality"] = {
-        default: levels[levels.length - 1]?.height ?? 0,
-        options: levels.map((level) => level.height),
-        forced: true,
-        onChange: (newQuality: number) => {
-          levels.forEach((level, levelIndex) => {
-            if (level.height === newQuality) {
-              hls.currentLevel = levelIndex;
-            }
-          });
-        },
-      };
-
-      player = new PlyrModule.default(videoElement, {
-        quality,
+      const plyrOptions: PlyrModule.Options = {
         autoplay: true,
         muted: true,
-      });
+      };
+
+      if (levels.length > 0) {
+        plyrOptions.quality = {
+          default: levels[levels.length - 1].height,
+          options: levels.map((level) => level.height),
+          forced: true,
+          onChange: (newQuality: number) => {
+            levels.forEach((level, levelIndex) => {
+              if (level.height === newQuality) {
+                hls.currentLevel = levelIndex;
+              }
+            });
+          },
+        };
+      }
+
+      player = new PlyrModule.default(videoElement, plyrOptions);
     });
 
     hls.attachMedia(videoElement);

--- a/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsPlyr.tsx
+++ b/packages/p2p-media-loader-demo/src/components/players/hlsjs/HlsjsPlyr.tsx
@@ -46,7 +46,7 @@ export const HlsjsPlyr = ({
       const { levels } = hls;
 
       const quality: PlyrModule.Options["quality"] = {
-        default: levels[levels.length - 1].height,
+        default: levels[levels.length - 1]?.height ?? 0,
         options: levels.map((level) => level.height),
         forced: true,
         onChange: (newQuality: number) => {

--- a/packages/p2p-media-loader-shaka/src/loading-handler.ts
+++ b/packages/p2p-media-loader-shaka/src/loading-handler.ts
@@ -36,7 +36,7 @@ export class Loader {
 
     const loading = this.defaultLoad() as LoadingHandlerResult;
     if (requestType === RequestType.MANIFEST) {
-      void this.handleManifestLoading(loading.promise);
+      this.handleManifestLoading(loading.promise).catch(() => undefined);
     }
     return loading;
   }

--- a/packages/p2p-media-loader-shaka/src/manifest-parser-decorator.ts
+++ b/packages/p2p-media-loader-shaka/src/manifest-parser-decorator.ts
@@ -155,8 +155,8 @@ export class ManifestParserDecorator implements shaka.extern.ManifestParser {
       callFromCreateSegmentIndexMethod = false,
     ) => {
       let prevReference: shaka.media.SegmentReference | null = null;
-      let prevFirstItemReference: shaka.media.SegmentReference;
-      let prevLastItemReference: shaka.media.SegmentReference;
+      let prevFirstItemReference: shaka.media.SegmentReference | undefined;
+      let prevLastItemReference: shaka.media.SegmentReference | undefined;
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       const originalGet = segmentIndex.get as (

--- a/packages/p2p-media-loader-shaka/src/stream-utils.ts
+++ b/packages/p2p-media-loader-shaka/src/stream-utils.ts
@@ -50,11 +50,12 @@ export function getByteRangeFromHeaderString(
 ): ByteRange | undefined {
   if (!rangeStr?.includes("bytes=")) return undefined;
 
-  const range = rangeStr
-    .split("=")[1]
-    .split("-")
-    .map((i) => parseInt(i));
-  const [start, end] = range;
+  const parts = rangeStr.split("=")[1].split("-");
+  const start = parseInt(parts[0]);
+  const end = parseInt(parts[1]);
+
+  if (isNaN(start) || isNaN(end)) return undefined;
+
   return { start, end };
 }
 


### PR DESCRIPTION
This PR fixes the following issues:

- Closes #542: Shaka - getByteRangeFromHeaderString returns NaN
- Closes #545: Core - isAndroidWebview fails modern detection
- Closes #546: Demo - Crash on empty hls.levels array
- Closes #547: Demo - Global window.Hls race condition
- Closes #548: Shaka - Unhandled promise rejection
- Closes #549: Shaka - Uninitialized TS variables
- Closes #551: Core - getSegmentAvgDuration returns NaN