### PR TITLE
feat: generate stable infohashes

### DIFF
--- a/packages/p2p-media-loader-hlsjs/src/segment-manager.ts
+++ b/packages/p2p-media-loader-hlsjs/src/segment-manager.ts
@@ -1,11 +1,23 @@
-import * as Utils from "./utils.js";
 import type {
-  ManifestLoadedData,
-  LevelUpdatedData,
   AudioTrackLoadedData,
   LevelParsed,
-} from "hls.js";
-import { Core, Segment, generateStreamShortId } from "p2p-media-loader-core";
+  LevelUpdatedData,
+  ManifestLoadedData,
+} from "hls.js"
+import { Core, Segment, generateStreamShortId } from "p2p-media-loader-core"
+import * as Utils from "./utils.js"
+
+type StreamToRegister = {
+  runtimeId: string;
+  sortKey: string;
+};
+
+function compareBySortKey(a: StreamToRegister, b: StreamToRegister) {
+  if (a.sortKey < b.sortKey) return -1;
+  if (a.sortKey > b.sortKey) return 1;
+
+  return 0;
+}
 
 export class SegmentManager {
   core: Core;
@@ -18,6 +30,8 @@ export class SegmentManager {
     const { levels, audioTracks } = data;
     // in the case of audio only stream it is stored in levels
 
+    const mainStreams: StreamToRegister[] = [];
+
     for (const level of levels) {
       const { url, bitrate, maxBitrate, videoCodec, width, height } =
         level as LevelParsed & { maxBitrate?: number };
@@ -28,7 +42,7 @@ export class SegmentManager {
       const frameRate = level.attrs["FRAME-RATE"];
       const videoRange = level.attrs["VIDEO-RANGE"];
 
-      const index = generateStreamShortId({
+      const sortKey = generateStreamShortId({
         bitrate: b,
         codecs: isMissingMetadata ? undefined : videoCodec,
         width: isMissingMetadata ? undefined : width,
@@ -36,29 +50,49 @@ export class SegmentManager {
         frameRate: isMissingMetadata ? undefined : frameRate,
         videoRange: isMissingMetadata ? undefined : videoRange,
       });
-      this.core.addStreamIfNoneExists({
+
+      mainStreams.push({
         runtimeId: Array.isArray(url) ? (url as string[])[0] : url,
-        type: "main",
-        index,
+        sortKey,
       });
     }
+
+    mainStreams.sort(compareBySortKey);
+    mainStreams.forEach((stream, index) => {
+      this.core.addStreamIfNoneExists({
+        runtimeId: stream.runtimeId,
+        type: "main",
+        index: index.toString(),
+      });
+    });
+
+    const secondaryStreams: StreamToRegister[] = [];
 
     for (const track of audioTracks) {
       // Object properties vary across hls.js versions so we cast to any:
       const { url, audioCodec, lang, channels, name } = track;
-      const index = generateStreamShortId({
+      const sortKey = generateStreamShortId({
         bitrate: 0, // Match Shaka behavior for audio stream without variant
         codecs: audioCodec,
         language: lang,
         channels,
         name,
       });
-      this.core.addStreamIfNoneExists({
+
+      secondaryStreams.push({
         runtimeId: Array.isArray(url) ? (url as string[])[0] : url,
-        type: "secondary",
-        index,
+        sortKey,
       });
     }
+
+    secondaryStreams.sort(compareBySortKey);
+    secondaryStreams.forEach((stream, index) => {
+      this.core.addStreamIfNoneExists({
+        runtimeId: stream.runtimeId,
+        type: "secondary",
+        index: index.toString(),
+      });
+    });
   }
 
   updatePlaylist(data: LevelUpdatedData | AudioTrackLoadedData) {

--- a/packages/p2p-media-loader-shaka/src/manifest-parser-decorator.ts
+++ b/packages/p2p-media-loader-shaka/src/manifest-parser-decorator.ts
@@ -1,18 +1,30 @@
-import type shaka from "shaka-player/dist/shaka-player.compiled.d.ts";
-import { SegmentManager } from "./segment-manager.js";
-import {
-  HookedStream,
-  Shaka,
-  HookedNetworkingEngine,
-  P2PMLShakaData,
-} from "./types.js";
 import {
   StreamType,
   debug,
   generateStreamShortId,
-} from "p2p-media-loader-core";
+} from "p2p-media-loader-core"
+import type shaka from "shaka-player/dist/shaka-player.compiled.d.ts"
+import { SegmentManager } from "./segment-manager.js"
+import {
+  HookedNetworkingEngine,
+  HookedStream,
+  P2PMLShakaData,
+  Shaka,
+} from "./types.js"
 
 const AUDIO_CODECS = ["mp4a", "ac-3", "ec-3", "ec+3", "opus", "vorb", "flac"];
+
+type StreamToProcess = {
+  stream: shaka.extern.Stream;
+  sortKey: string;
+};
+
+function compareBySortKey(a: StreamToProcess, b: StreamToProcess) {
+  if (a.sortKey < b.sortKey) return -1;
+  if (a.sortKey > b.sortKey) return 1;
+
+  return 0;
+}
 
 export class ManifestParserDecorator implements shaka.extern.ManifestParser {
   private readonly debug = debug("p2pml-shaka:manifest-parser");
@@ -89,7 +101,7 @@ export class ManifestParserDecorator implements shaka.extern.ManifestParser {
     const { segmentManager } = this;
     if (!segmentManager) return;
 
-    const processedStreams = new Set<number>();
+    const collectedStreams = new Set<number>();
     const processStream = (
       stream: shaka.extern.Stream,
       type: StreamType,
@@ -97,14 +109,17 @@ export class ManifestParserDecorator implements shaka.extern.ManifestParser {
     ) => {
       this.hookSegmentIndex(stream);
       segmentManager.setStream(stream, type, index);
-      processedStreams.add(stream.id);
       return true;
     };
+
+    const mainStreams: StreamToProcess[] = [];
+    const secondaryStreams: StreamToProcess[] = [];
 
     for (const variant of variants) {
       const { video, audio } = variant;
 
-      if (video && !processedStreams.has(video.id)) {
+      if (video && !collectedStreams.has(video.id)) {
+        collectedStreams.add(video.id);
         const isMissingMetadata = variant.bandwidth === 0;
         // In muxed streams, Shaka natively includes audio codecs in the video codec array.
         // We strip standard audio prefixes here to strictly match HLS.js's cleanly separated
@@ -120,7 +135,7 @@ export class ManifestParserDecorator implements shaka.extern.ManifestParser {
 
         const { frameRate, hdr: videoRange } = video;
 
-        const index = generateStreamShortId({
+        const sortKey = generateStreamShortId({
           bitrate: variant.bandwidth,
           codecs: isMissingMetadata ? undefined : videoCodecs,
           width: isMissingMetadata ? undefined : video.width,
@@ -128,22 +143,49 @@ export class ManifestParserDecorator implements shaka.extern.ManifestParser {
           frameRate: isMissingMetadata ? undefined : frameRate,
           videoRange: isMissingMetadata ? undefined : videoRange,
         });
-        processStream(video, "main", index);
+
+        mainStreams.push({
+          stream: video,
+          sortKey,
+        });
       }
-      if (audio && !processedStreams.has(audio.id)) {
+
+      if (audio && !collectedStreams.has(audio.id)) {
+        collectedStreams.add(audio.id);
         const isMain = !video; // audio-only master playlist variants
         const name = audio.label ?? audio.originalId ?? undefined;
 
-        const index = generateStreamShortId({
+        const sortKey = generateStreamShortId({
           bitrate: isMain ? variant.bandwidth : 0,
           codecs: isMain ? undefined : audio.codecs,
           language: isMain ? undefined : audio.language,
           channels: isMain ? undefined : audio.channelsCount,
           name: isMain ? undefined : name,
         });
-        processStream(audio, isMain ? "main" : "secondary", index);
+
+        if (isMain) {
+          mainStreams.push({
+            stream: audio,
+            sortKey,
+          });
+        } else {
+          secondaryStreams.push({
+            stream: audio,
+            sortKey,
+          });
+        }
       }
     }
+
+    mainStreams.sort(compareBySortKey);
+    mainStreams.forEach((item, index) => {
+      processStream(item.stream, "main", index.toString());
+    });
+
+    secondaryStreams.sort(compareBySortKey);
+    secondaryStreams.forEach((item, index) => {
+      processStream(item.stream, "secondary", index.toString());
+    });
   }
 
   private hookSegmentIndex(stream: HookedStream): void {
@@ -261,7 +303,7 @@ export class ManifestParserDecorator implements shaka.extern.ManifestParser {
     }
 
     // For version 4.2; Retrieving mediaSequence map for each HLS playlist
-    const manifestVariantsMap = maps.find((map: Map<unknown, unknown>) => {
+    const manifestVariantsMap = maps.find((map) => {
       const item = map.values().next().value;
 
       return (
@@ -280,7 +322,7 @@ export class ManifestParserDecorator implements shaka.extern.ManifestParser {
 
       const mediaSequenceTimeMap = getMapPropertiesFromObject(
         variant as Record<string, unknown>,
-      ).find((map: Map<unknown, unknown>) => {
+      ).find((map) => {
         const [key, value] = map.entries().next().value ?? [];
         return typeof key === "number" && typeof value === "number";
       });


### PR DESCRIPTION
Re-use the same infohash structure as v2 (using index suffix) while keeping index order between hls.js and shaka player. 

Allows backend to easily run a private tracker with expected infohashes.